### PR TITLE
Fix Eigen 3.3.0 compilation failure with modern Clang

### DIFF
--- a/Eigen/src/Core/Transpositions.h
+++ b/Eigen/src/Core/Transpositions.h
@@ -384,7 +384,7 @@ class Transpose<TranspositionsBase<TranspositionsDerived> >
     const Product<OtherDerived, Transpose, AliasFreeProduct>
     operator*(const MatrixBase<OtherDerived>& matrix, const Transpose& trt)
     {
-      return Product<OtherDerived, Transpose, AliasFreeProduct>(matrix.derived(), trt.derived());
+      return Product<OtherDerived, Transpose, AliasFreeProduct>(matrix.derived(), trt);
     }
 
     /** \returns the \a matrix with the inverse transpositions applied to the rows.


### PR DESCRIPTION
Building on MacOS 26.4 I ran into a compile error.

The Transpose<TranspositionsBase<T>> partial specialization does not inherit from TranspositionsBase, so it has no derived() method. The bundled Eigen 3.3.0 calls trt.derived() in a friend operator* overload inside this class, which older compilers accepted but modern Apple Clang (21.x / Xcode 16+) correctly rejects.

Since trt is already the concrete Transpose type, derived() would be a no-op even if it existed. Replace trt.derived() with trt.