### PR TITLE
Add --IncludeChr to replace hardcoded human chromosome filter

### DIFF
--- a/SVDcalculator.cpp
+++ b/SVDcalculator.cpp
@@ -18,7 +18,8 @@ SVDcalculator::~SVDcalculator() {}
 
 int SVDcalculator::ReadVcf(const std::string &VcfPath,
                            std::vector<std::vector<char> >& genotype,
-                           int & nSamples, int& nMarkers) {
+                           int & nSamples, int& nMarkers,
+                           const std::unordered_set<std::string>& includeChr) {
     try {
         int maxPhred=255;
         VcfFile *pVcf = new VcfFile;
@@ -34,12 +35,10 @@ int SVDcalculator::ReadVcf(const std::string &VcfPath,
                                    VcfPath.c_str());
         }
 
-        std::unordered_set<std::string> acceptChr={"1","2","3","4","5","6","7","8","9","10",
-                                              "11","12","13","14","15","16","17","18","19","20",
-                                              "21","22",
-                                              "chr1", "chr2", "chr3","chr4","chr5","chr6","chr7","chr8", "chr9","chr10",
-                                              "chr11","chr12","chr13","chr14","chr15","chr16","chr17", "chr18","chr19",
-                                              "chr20","chr21","chr22"};
+        bool filterByChrom = !includeChr.empty();
+        if (filterByChrom) {
+            notice("Filtering to %d chromosome(s) specified by --IncludeChr", (int)includeChr.size());
+        }
 
         nSamples = pVcf->getSampleCount();
         nMarkers = 0;
@@ -71,9 +70,8 @@ int SVDcalculator::ReadVcf(const std::string &VcfPath,
                 warning("Skip non-SNP marker: %s",markerName.c_str());
                 continue;
             }
-            if(acceptChr.find(std::string(pMarker->sChrom.c_str())) == acceptChr.end())
+            if(filterByChrom && includeChr.find(std::string(pMarker->sChrom.c_str())) == includeChr.end())
             {
-              warning("Skip non-autosome marker: %s",markerName.c_str());
               continue;
             }
             refAllele=pMarker->sRef[0];
@@ -201,12 +199,13 @@ int SVDcalculator::ReadVcf(const std::string &VcfPath,
     return 0;
 }
 
-void SVDcalculator::ProcessRefVCF(const std::string &VcfPath)
+void SVDcalculator::ProcessRefVCF(const std::string &VcfPath,
+                                  const std::unordered_set<std::string>& includeChr)
 {
 
     std::vector<std::vector<char> > genotype;//markers X samples
 
-    ReadVcf(VcfPath, genotype, numIndividual, numMarker);
+    ReadVcf(VcfPath, genotype, numIndividual, numMarker, includeChr);
     MatrixXf genoMatrix(numMarker,numIndividual);
 //    std::cerr<<numMarker<<"\t"<<genotype.size()<<"\t"<<numIndividual<<"\t"<<genotype[0].size()<<std::endl;
     notice("Number of Markers:%d",numMarker);

--- a/SVDcalculator.h
+++ b/SVDcalculator.h
@@ -4,6 +4,7 @@
 
 #include <vector>
 #include <map>
+#include <unordered_set>
 #include "SimplePileupViewer.h"
 
 class SVDcalculator {
@@ -21,12 +22,20 @@ private:
 public:
     SVDcalculator();
     ~SVDcalculator();
-    void ProcessRefVCF(const std::string& VcfPath);
+
+    /// Read a reference VCF, compute SVD, and write .UD, .mu, .bed, .V files.
+    /// @param includeChr  if non-empty, only markers on these chromosomes are used
+    void ProcessRefVCF(const std::string& VcfPath,
+                       const std::unordered_set<std::string>& includeChr);
+
+    /// Parse a VCF into a genotype matrix.
+    /// @param includeChr  if non-empty, only markers on these chromosomes are used
     int ReadVcf(const std::string &VcfPath,
                 std::vector<std::vector<char> >& genotype,
-                int & nSamples, int& nMarkers);
-//    int Decompose();
-    std::vector<std::vector<double>> GetUDMatrix();//return the matrix
+                int & nSamples, int& nMarkers,
+                const std::unordered_set<std::string>& includeChr);
+
+    std::vector<std::vector<double>> GetUDMatrix();
     std::vector<std::vector<double>> GetPCMatrix();
     std::vector<PCtype> GetMuArray();
     BED GetchooseBed();

--- a/main.cpp
+++ b/main.cpp
@@ -24,6 +24,7 @@ SOFTWARE.
 #include <iostream>
 #include <sstream>
 #include <stdexcept>
+#include <unordered_set>
 
 #include "ContaminationEstimator.h"
 #include "PhoneHome.h"
@@ -42,6 +43,12 @@ int execute(int argc, char **argv) {
       SVDPrefix("Empty");
   std::string knownAF("Empty");
   std::string RefVCF("Empty");
+  // Default to human autosomes (both with and without "chr" prefix).
+  // Override with --IncludeChr for non-human species.
+  std::string includeChrStr("1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,"
+                            "chr1,chr2,chr3,chr4,chr5,chr6,chr7,chr8,chr9,chr10,"
+                            "chr11,chr12,chr13,chr14,chr15,chr16,chr17,chr18,chr19,"
+                            "chr20,chr21,chr22");
   std::string fixPC("Empty");
   double fixAlpha(-1.), epsilon(1e-8);
   bool withinAncestry(false), outputPileup(false), verbose(false),
@@ -119,6 +126,10 @@ int execute(int argc, char **argv) {
                     "[String] VCF file from which to extract reference "
                     "panel's genotype matrix[Required if no SVD files "
                     "available]")
+  LONG_STRING_PARAM("IncludeChr", &includeChrStr,
+                    "[String] Comma-separated list of chromosome names to "
+                    "include when building SVD from --RefVCF. "
+                    "[default:human autosomes 1-22/chr1-chr22]")
   LONG_PARAM_GROUP("Pileup Options", "Arguments for pileup info extraction")
   LONG_INT_PARAM("min-BQ", &mplp.min_baseQ,
                  "[Int] skip bases with baseQ/BAQ smaller than min-BQ")
@@ -185,8 +196,21 @@ int execute(int argc, char **argv) {
            "[RefVCF path].mu");
     notice("You may specify --SVDPrefix [RefVCF path](or --UDPath [RefVCF "
            "path].UD and --MeanPath [RefVCF path].mu) in future use");
+    // Parse --IncludeChr comma-separated list into a set of chromosome names
+    std::unordered_set<std::string> includeChrSet;
+    {
+        std::stringstream ss(includeChrStr);
+        std::string token;
+        while (std::getline(ss, token, ',')) {
+            if (!token.empty()) {
+                includeChrSet.insert(token);
+            }
+        }
+    }
+    notice("--IncludeChr: filtering to %d chromosome name(s)", (int)includeChrSet.size());
+
     SVDcalculator calculator;
-    calculator.ProcessRefVCF(RefVCF);
+    calculator.ProcessRefVCF(RefVCF, includeChrSet);
     UDPath = RefVCF + ".UD";
     MeanPath = RefVCF + ".mu";
     BedPath = RefVCF + ".bed";


### PR DESCRIPTION
The --RefVCF SVD generation path had a hardcoded set of accepted chromosome names (human autosomes 1-22 and chr1-chr22). Any marker on a chromosome not in this set was silently skipped, making --RefVCF non-functional for non-human reference panels.

Replace the hardcoded set with a configurable --IncludeChr parameter (comma-separated chromosome names). The default value is the same human autosome list, preserving existing behavior. Users working with other species override this, e.g.:

  --IncludeChr A1,A2,A3,B1,B2,B3,B4,C1,C2,D1,D2,D3,D4,E1,E2,E3,F1,F2

The reason for this is that I'm attempting to use VerifyBamID with cats (Felis catus)!  The chromosome names do not follow human chromosome name conventions, but there is no reason that VerifyBamID shouldn't work correctly on cats, given sufficient samples to model the population(s).