### PR TITLE
Fix per-sample genotype parsing to fall back from PL to GL to GT

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,7 +69,13 @@ add_executable(VerifyBamID ${SOURCE_FILES})
 
 target_link_libraries(VerifyBamID statgen Vcf ${HTS_LIBRARIES} samtools ${ZLIB} ${BZIP2} ${LZMA} ${CURLLIB})
 
+add_executable(TestReadVcf TestReadVcf.cpp SVDcalculator.cpp)
+target_link_libraries(TestReadVcf statgen Vcf ${HTS_LIBRARIES} samtools ${ZLIB} ${BZIP2} ${LZMA} ${CURLLIB})
+
 enable_testing()
+add_test(NAME testReadVcf
+        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+        COMMAND TestReadVcf resource/test/test_readvcf.vcf)
 add_test(NAME myTest1
         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
         COMMAND VerifyBamID --DisableSanityCheck --BamFile resource/test/test.bam --SVDPrefix resource/test/hapmap_3.3.b37.dat --Reference resource/test/chr20.fa.gz --NumPC 2)

--- a/SVDcalculator.cpp
+++ b/SVDcalculator.cpp
@@ -79,22 +79,21 @@ int SVDcalculator::ReadVcf(const std::string &VcfPath,
             refAllele=pMarker->sRef[0];
             altAllele=pMarker->asAlts[0][0];
 
-            int PLidx = pMarker->asFormatKeys.Find("PL");
-            int PLGLGTflag = 0;//0 for PL, 1 for GL, 2 for GT
-            if (PLidx < 0) {
-                PLidx = pMarker->asFormatKeys.Find("GL");
-                if (PLidx >= 0) PLGLGTflag = 1;//found GL
-                else {
-                    PLidx = pMarker->asFormatKeys.Find("GT");
-                    if(PLidx >= 0) PLGLGTflag = 2;//found GT
-                    else throw VcfFileException("Cannot recognize GT, GL or PL key in FORMAT field");
-                }
+            // Look up FORMAT field indices for genotype data. A marker's FORMAT
+            // may contain any combination of PL, GL, and GT. Individual samples
+            // may have missing values for some fields, so we try each per-sample
+            // in priority order: PL > GL > GT.
+            int idxPL = pMarker->asFormatKeys.Find("PL");
+            int idxGL = pMarker->asFormatKeys.Find("GL");
+            int idxGT = pMarker->asFormatKeys.Find("GT");
+            if (idxPL < 0 && idxGL < 0 && idxGT < 0) {
+                throw VcfFileException("Cannot recognize GT, GL or PL key in FORMAT field");
             }
             int formatLength = pMarker->asFormatKeys.Length();
-            int idx11 = 0, idx12 = 1, idx22 = 2;
-
             StringArray phred;
 
+            // Phred-scaled likelihoods for the three diploid genotypes:
+            // phred11 = P(data|0/0), phred12 = P(data|0/1), phred22 = P(data|1/1)
             long phred11 = 0;
             long phred12 = 0;
             long phred22 = 0;
@@ -103,51 +102,60 @@ int SVDcalculator::ReadVcf(const std::string &VcfPath,
             for (int i = 0; i < nSamples; i++)//for each individual
             {
                     if(nMarkers==0) Samples.push_back(pVcf->getSampleID(i).c_str());
-                    if(PLGLGTflag==0)//found PL
-                    {
-                        phred.ReplaceTokens(pMarker->asSampleValues[PLidx + i * formatLength], ",");
+
+                    bool parsed = false;
+
+                    // Try PL: phred-scaled genotype likelihoods (3 comma-separated ints)
+                    if (!parsed && idxPL >= 0) {
+                        phred.ReplaceTokens(pMarker->asSampleValues[idxPL + i * formatLength], ",");
                         if (phred.Length() == 3 && phred[0] != ".") {
-                          phred11 = phred[idx11].AsInteger();
-                          phred12 = phred[idx12].AsInteger();
-                          phred22 = phred[idx22].AsInteger();
+                          phred11 = phred[0].AsInteger();
+                          phred12 = phred[1].AsInteger();
+                          phred22 = phred[2].AsInteger();
+                          parsed = true;
                         }
-                        else nMissingGenoSamples++;
                     }
-                    else if(PLGLGTflag == 1)//found GL
-                    {
-                        phred.ReplaceTokens(pMarker->asSampleValues[PLidx + i * formatLength], ",");
+                    // Try GL: log10 genotype likelihoods (3 comma-separated floats),
+                    // converted to phred scale
+                    if (!parsed && idxGL >= 0) {
+                        phred.ReplaceTokens(pMarker->asSampleValues[idxGL + i * formatLength], ",");
                         if (phred.Length() == 3 && phred[0] != ".") {
                           phred11 =
-                              static_cast<int>(-10. * phred[idx11].AsDouble());
+                              static_cast<int>(-10. * phred[0].AsDouble());
                           phred12 =
-                              static_cast<int>(-10. * phred[idx12].AsDouble());
+                              static_cast<int>(-10. * phred[1].AsDouble());
                           phred22 =
-                              static_cast<int>(-10. * phred[idx22].AsDouble());
+                              static_cast<int>(-10. * phred[2].AsDouble());
+                          parsed = true;
                         }
-                        else nMissingGenoSamples++;
                     }
-                    else//found GT
-                    {
-                        phred.ReplaceTokens(pMarker->asSampleValues[PLidx + i * formatLength], "|/");
-                        if (phred.Length() == 3 && phred[0] != ".") {
+                    // Try GT: hard-call genotype (two allele indices separated by
+                    // / or |). Synthesize high-confidence phred scores from the
+                    // hard call since no likelihoods are available.
+                    if (!parsed && idxGT >= 0) {
+                        StringArray alleles;
+                        alleles.ReplaceTokens(pMarker->asSampleValues[idxGT + i * formatLength], "|/");
+                        if (alleles.Length() == 2 && alleles[0] != ".") {
                           long geno =
-                              phred[0].AsInteger() + phred[1].AsInteger();
-                          if (geno == 0) {
+                              alleles[0].AsInteger() + alleles[1].AsInteger();
+                          if (geno == 0) {        // 0/0: homozygous ref
                             phred11 = 0;
                             phred12 = 30;
                             phred22 = 50;
-                          } else if (geno == 1) {
+                          } else if (geno == 1) { // 0/1: heterozygous
                             phred11 = 50;
                             phred12 = 0;
                             phred22 = 50;
-                          } else {
+                          } else {                // 1/1: homozygous alt
                             phred11 = 50;
                             phred12 = 30;
                             phred22 = 0;
                           }
+                          parsed = true;
                         }
-                        else nMissingGenoSamples++;
                     }
+
+                    if (!parsed) nMissingGenoSamples++;
 
                     if ((phred11 < 0) || (phred12 < 0) || (phred22 < 0)) {
                         error("Negative PL or Positive GL observed");
@@ -156,8 +164,8 @@ int SVDcalculator::ReadVcf(const std::string &VcfPath,
                     if (phred11 > maxPhred) phred11 = maxPhred;
                     if (phred12 > maxPhred) phred12 = maxPhred;
                     if (phred22 > maxPhred) phred22 = maxPhred;
-//
-//                    printf("phred scores are %f, %f, %f;\tphred11/12/22 %d, %d, %d\n", phred[idx11].AsDouble(), phred[idx12].AsDouble(), phred[idx22].AsDouble(),phred11,phred12,phred22);
+
+                    // Pick the most likely genotype (lowest phred = highest likelihood)
                     int minGeno = -1;
                     long minPhred = maxPhred;
                     if(phred11 < minPhred)

--- a/SVDcalculator.cpp
+++ b/SVDcalculator.cpp
@@ -108,7 +108,7 @@ int SVDcalculator::ReadVcf(const std::string &VcfPath,
                     // Try PL: phred-scaled genotype likelihoods (3 comma-separated ints)
                     if (!parsed && idxPL >= 0) {
                         phred.ReplaceTokens(pMarker->asSampleValues[idxPL + i * formatLength], ",");
-                        if (phred.Length() == 3 && phred[0] != ".") {
+                        if (phred.Length() == 3 && phred[0] != "." && phred[1] != "." && phred[2] != ".") {
                           phred11 = phred[0].AsInteger();
                           phred12 = phred[1].AsInteger();
                           phred22 = phred[2].AsInteger();
@@ -119,7 +119,7 @@ int SVDcalculator::ReadVcf(const std::string &VcfPath,
                     // converted to phred scale
                     if (!parsed && idxGL >= 0) {
                         phred.ReplaceTokens(pMarker->asSampleValues[idxGL + i * formatLength], ",");
-                        if (phred.Length() == 3 && phred[0] != ".") {
+                        if (phred.Length() == 3 && phred[0] != "." && phred[1] != "." && phred[2] != ".") {
                           phred11 =
                               static_cast<int>(-10. * phred[0].AsDouble());
                           phred12 =
@@ -135,7 +135,7 @@ int SVDcalculator::ReadVcf(const std::string &VcfPath,
                     if (!parsed && idxGT >= 0) {
                         StringArray alleles;
                         alleles.ReplaceTokens(pMarker->asSampleValues[idxGT + i * formatLength], "|/");
-                        if (alleles.Length() == 2 && alleles[0] != ".") {
+                        if (alleles.Length() == 2 && alleles[0] != "." && alleles[1] != ".") {
                           long geno =
                               alleles[0].AsInteger() + alleles[1].AsInteger();
                           if (geno == 0) {        // 0/0: homozygous ref

--- a/SVDcalculator.cpp
+++ b/SVDcalculator.cpp
@@ -92,17 +92,17 @@ int SVDcalculator::ReadVcf(const std::string &VcfPath,
             int formatLength = pMarker->asFormatKeys.Length();
             StringArray phred;
 
-            // Phred-scaled likelihoods for the three diploid genotypes:
-            // phred11 = P(data|0/0), phred12 = P(data|0/1), phred22 = P(data|1/1)
-            long phred11 = 0;
-            long phred12 = 0;
-            long phred22 = 0;
             std::vector<char> perMarkerGeno(nSamples,-1);
             int nMissingGenoSamples = 0;
             for (int i = 0; i < nSamples; i++)//for each individual
             {
                     if(nMarkers==0) Samples.push_back(pVcf->getSampleID(i).c_str());
 
+                    // Phred-scaled likelihoods for the three diploid genotypes:
+                    // phred11 = P(data|0/0), phred12 = P(data|0/1), phred22 = P(data|1/1)
+                    long phred11 = 0;
+                    long phred12 = 0;
+                    long phred22 = 0;
                     bool parsed = false;
 
                     // Try PL: phred-scaled genotype likelihoods (3 comma-separated ints)
@@ -155,7 +155,10 @@ int SVDcalculator::ReadVcf(const std::string &VcfPath,
                         }
                     }
 
-                    if (!parsed) nMissingGenoSamples++;
+                    if (!parsed) {
+                        nMissingGenoSamples++;
+                        continue;
+                    }
 
                     if ((phred11 < 0) || (phred12 < 0) || (phred22 < 0)) {
                         error("Negative PL or Positive GL observed");

--- a/TestReadVcf.cpp
+++ b/TestReadVcf.cpp
@@ -1,0 +1,137 @@
+/// Integration test for SVDcalculator::ReadVcf genotype parsing.
+///
+/// Reads a test VCF that encodes expected AF and N_MISSING in each row's INFO
+/// field, calls ReadVcf, then validates the genotype matrix produces matching
+/// values. This exercises PL/GL/GT parsing, per-sample fallback, partial-missing
+/// handling, and phased genotypes.
+
+#include "SVDcalculator.h"
+#include <cmath>
+#include <cstdlib>
+#include <fstream>
+#include <iostream>
+#include <sstream>
+#include <string>
+#include <vector>
+
+struct Expected {
+    std::string testDesc;
+    double af;
+    int nMissing;
+};
+
+/// Parse EXPECTED_AF, EXPECTED_N_MISSING, and TESTDESC from the INFO column of
+/// each data line in the VCF. Only includes rows with FILTER=PASS (matching
+/// ReadVcf's filtering behavior).
+static std::vector<Expected> parseExpected(const std::string& vcfPath) {
+    std::vector<Expected> result;
+    std::ifstream fin(vcfPath);
+    std::string line;
+
+    while (std::getline(fin, line)) {
+        if (line.empty() || line[0] == '#') continue;
+
+        // Split line by tab
+        std::vector<std::string> cols;
+        std::istringstream iss(line);
+        std::string col;
+        while (std::getline(iss, col, '\t')) cols.push_back(col);
+        if (cols.size() < 8) continue;
+
+        // Only include PASS rows (ReadVcf skips non-PASS)
+        if (cols[6] != "PASS") continue;
+
+        Expected ev;
+        ev.testDesc = "unknown";
+        ev.af = -1.0;
+        ev.nMissing = -1;
+
+        // Parse semicolon-delimited INFO field
+        std::istringstream infoStream(cols[7]);
+        std::string field;
+        while (std::getline(infoStream, field, ';')) {
+            size_t eq = field.find('=');
+            if (eq == std::string::npos) continue;
+            std::string key = field.substr(0, eq);
+            std::string val = field.substr(eq + 1);
+            if (key == "TESTDESC")           ev.testDesc = val;
+            else if (key == "EXPECTED_AF")   ev.af = std::stod(val);
+            else if (key == "EXPECTED_N_MISSING") ev.nMissing = std::stoi(val);
+        }
+
+        result.push_back(ev);
+    }
+    return result;
+}
+
+int main(int argc, char** argv) {
+    if (argc != 2) {
+        std::cerr << "Usage: " << argv[0] << " <test.vcf>" << std::endl;
+        return 1;
+    }
+    std::string vcfPath = argv[1];
+
+    // Run ReadVcf
+    SVDcalculator calc;
+    std::vector<std::vector<char>> genotype;
+    int nSamples = 0, nMarkers = 0;
+    std::unordered_set<std::string> includeChr;
+    calc.ReadVcf(vcfPath, genotype, nSamples, nMarkers, includeChr);
+
+    // Parse expected values from VCF INFO fields
+    std::vector<Expected> expected = parseExpected(vcfPath);
+
+    if (nMarkers != static_cast<int>(expected.size())) {
+        std::cerr << "FAIL: expected " << expected.size()
+                  << " markers but ReadVcf returned " << nMarkers << std::endl;
+        return 1;
+    }
+
+    int failures = 0;
+    for (int m = 0; m < nMarkers; m++) {
+        const auto& geno = genotype[m];
+        const auto& exp  = expected[m];
+
+        // Compute observed N_MISSING and AF from the genotype vector
+        int nMissing    = 0;
+        int sumGeno     = 0;
+        int nNonMissing = 0;
+        for (int s = 0; s < nSamples; s++) {
+            if (geno[s] < 0) {
+                nMissing++;
+            } else {
+                sumGeno += geno[s];
+                nNonMissing++;
+            }
+        }
+        double af = (nNonMissing > 0)
+            ? static_cast<double>(sumGeno) / (2.0 * nNonMissing)
+            : 0.0;
+
+        bool ok = true;
+        if (nMissing != exp.nMissing) {
+            std::cerr << "FAIL [" << exp.testDesc << "]: N_MISSING expected "
+                      << exp.nMissing << " got " << nMissing << std::endl;
+            ok = false;
+        }
+        if (std::fabs(af - exp.af) > 0.001) {
+            std::cerr << "FAIL [" << exp.testDesc << "]: AF expected "
+                      << exp.af << " got " << af << std::endl;
+            ok = false;
+        }
+
+        if (ok) {
+            std::cerr << "PASS [" << exp.testDesc << "]" << std::endl;
+        } else {
+            failures++;
+        }
+    }
+
+    if (failures > 0) {
+        std::cerr << failures << " of " << nMarkers << " test(s) FAILED" << std::endl;
+        return 1;
+    }
+
+    std::cerr << "All " << nMarkers << " tests passed" << std::endl;
+    return 0;
+}

--- a/resource/test/test_readvcf.vcf
+++ b/resource/test/test_readvcf.vcf
@@ -1,0 +1,20 @@
+##fileformat=VCFv4.1
+##INFO=<ID=TESTDESC,Number=1,Type=String,Description="Description of what this VCF row tests">
+##INFO=<ID=EXPECTED_AF,Number=1,Type=Float,Description="Expected alt allele frequency computed from correctly parsed genotypes">
+##INFO=<ID=EXPECTED_N_MISSING,Number=1,Type=Integer,Description="Expected number of samples with missing genotypes after parsing">
+##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
+##FORMAT=<ID=PL,Number=G,Type=Integer,Description="Phred-scaled genotype likelihoods">
+##FORMAT=<ID=GL,Number=G,Type=Float,Description="Log10-scaled genotype likelihoods">
+#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	S01	S02	S03	S04	S05	S06	S07	S08	S09	S10
+20	100000	.	A	T	60	PASS	TESTDESC=PL_only_all_present;EXPECTED_AF=0.45;EXPECTED_N_MISSING=0	PL	0,30,50	0,30,50	50,0,50	50,0,50	50,30,0	50,30,0	0,30,50	50,0,50	50,30,0	0,30,50
+20	101000	.	A	T	60	PASS	TESTDESC=GL_only_all_present;EXPECTED_AF=0.45;EXPECTED_N_MISSING=0	GL	0,-3,-5	0,-3,-5	-5,0,-5	-5,0,-5	-5,-3,0	-5,-3,0	0,-3,-5	-5,0,-5	-5,-3,0	0,-3,-5
+20	102000	.	A	T	60	PASS	TESTDESC=GT_only_all_present;EXPECTED_AF=0.45;EXPECTED_N_MISSING=0	GT	0/0	0/0	0/1	0/1	1/1	1/1	0/0	0/1	1/1	0/0
+20	103000	.	A	T	60	PASS	TESTDESC=PL_missing_falls_back_to_GT;EXPECTED_AF=0.45;EXPECTED_N_MISSING=0	GT:PL	0/0:0,30,50	0/0:.	0/1:50,0,50	0/1:.	1/1:50,30,0	1/1:.	0/0:0,30,50	0/1:50,0,50	1/1:50,30,0	0/0:0,30,50
+20	104000	.	A	T	60	PASS	TESTDESC=GL_missing_falls_back_to_GT;EXPECTED_AF=0.45;EXPECTED_N_MISSING=0	GT:GL	0/0:0,-3,-5	0/0:.	0/1:-5,0,-5	0/1:.	1/1:-5,-3,0	1/1:.	0/0:0,-3,-5	0/1:-5,0,-5	1/1:-5,-3,0	0/0:0,-3,-5
+20	105000	.	A	T	60	PASS	TESTDESC=PL_GL_GT_cascade_fallback;EXPECTED_AF=0.45;EXPECTED_N_MISSING=0	GT:PL:GL	0/0:0,30,50:0,-3,-5	0/1:.:-5,0,-5	1/1:.:.	0/0:0,30,50:0,-3,-5	0/1:.:-5,0,-5	1/1:.:.	0/0:0,30,50:0,-3,-5	0/1:.:-5,0,-5	1/1:50,30,0:-5,-3,0	0/0:.:0,-3,-5
+20	106000	.	A	T	60	PASS	TESTDESC=PL_partial_missing_falls_back_to_GT;EXPECTED_AF=0.35;EXPECTED_N_MISSING=0	GT:PL	0/0:50,.,.	0/0:0,30,50	0/1:50,0,50	0/0:50,.,30	0/1:50,0,50	1/1:50,30,0	0/0:0,30,50	0/1:50,0,50	1/1:50,30,0	0/0:0,30,50
+20	107000	.	A	T	60	PASS	TESTDESC=GL_partial_missing_falls_back_to_GT;EXPECTED_AF=0.35;EXPECTED_N_MISSING=0	GT:GL	0/0:-5,.,.	0/0:0,-3,-5	0/1:-5,0,-5	0/0:-5,.,0	0/1:-5,0,-5	1/1:-5,-3,0	0/0:0,-3,-5	0/1:-5,0,-5	1/1:-5,-3,0	0/0:0,-3,-5
+20	108000	.	A	T	60	PASS	TESTDESC=GT_partial_missing_one_allele;EXPECTED_AF=0.5;EXPECTED_N_MISSING=1	GT	0/0	./1	0/1	0/1	1/1	1/1	0/0	0/1	1/1	0/0
+20	109000	.	A	T	60	PASS	TESTDESC=GT_phased_genotypes;EXPECTED_AF=0.45;EXPECTED_N_MISSING=0	GT	0|0	0|0	0|1	1|0	1|1	1|1	0|0	0|1	1|1	0|0
+20	110000	.	A	T	60	PASS	TESTDESC=all_fields_missing_two_samples;EXPECTED_AF=0.4375;EXPECTED_N_MISSING=2	GT:PL:GL	0/0:0,30,50:0,-3,-5	0/1:50,0,50:-5,0,-5	./.:.:.	1/1:50,30,0:-5,-3,0	0/0:0,30,50:0,-3,-5	./.:.:.	0/1:50,0,50:-5,0,-5	1/1:50,30,0:-5,-3,0	0/0:0,30,50:0,-3,-5	0/1:50,0,50:-5,0,-5
+20	111000	.	A	T	60	PASS	TESTDESC=PL_takes_priority_over_GL;EXPECTED_AF=0.45;EXPECTED_N_MISSING=0	GT:PL:GL	0/0:0,30,50:-5,0,-5	0/1:50,0,50:0,-3,-5	1/1:50,30,0:-5,-3,0	0/0:0,30,50:-5,0,-5	0/1:50,0,50:0,-3,-5	1/1:50,30,0:-5,-3,0	0/0:0,30,50:-5,0,-5	0/1:50,0,50:0,-3,-5	1/1:50,30,0:-5,-3,0	0/0:0,30,50:0,-3,-5


### PR DESCRIPTION
I encountered two issues in SVDcalculator::ReadVcf genotype parsing:

1. The code selected a single FORMAT field strategy (PL, GL, or GT) per marker and used it for all samples. If PL was present in the FORMAT header but a specific sample had PL=., that sample was counted as missing even when a valid GT was available for it. This is common in GATK-generated multi-sample call sets where homref genotypes computed from ref blocks in gVCF may not get PLs, but samples with non-`0/0` genotypes do.

2. The GT branch checked for 3 tokens after splitting the genotype by "|/", but a diploid genotype like "0/1" splits into 2 tokens, not 3. This meant every GT-only sample was always counted as missing, and markers quickly exceeded the 20% missing-rate threshold.  I think the check for a 3-way split was just a copy/paste mistake from the code above where it splits the PL and GL fields.

Fix: look up PL, GL, and GT indices per marker, then for each sample try them in priority order (PL > GL > GT), falling back when a field is missing. The GT branch now correctly checks for 2 tokens and uses a separate `alleles` variable rather than reusing `phred`.