### PR TITLE
Performance tuning of FREEMIX calculations from BAM

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -78,22 +78,25 @@ add_test(NAME testReadVcf
         COMMAND TestReadVcf resource/test/test_readvcf.vcf)
 add_test(NAME myTest1
         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-        COMMAND VerifyBamID --DisableSanityCheck --BamFile resource/test/test.bam --SVDPrefix resource/test/hapmap_3.3.b37.dat --Reference resource/test/chr20.fa.gz --NumPC 2)
+        COMMAND VerifyBamID --DisableSanityCheck --BamFile resource/test/test.bam --SVDPrefix resource/test/hapmap_3.3.b37.dat --Reference resource/test/chr20.fa.gz --NumPC 2 --Output result.myTest1)
 add_test(NAME myTest2
         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-        COMMAND sh -c "diff resource/test/expected/result.Ancestry result.Ancestry && rm result.Ancestry result.selfSM")
+        COMMAND sh -c "diff resource/test/expected/result.Ancestry result.myTest1.Ancestry && rm result.myTest1.Ancestry result.myTest1.selfSM")
+set_tests_properties(myTest2 PROPERTIES DEPENDS myTest1)
 add_test(NAME myTest3
         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-        COMMAND VerifyBamID --DisableSanityCheck --PileupFile resource/test/expected/result.Pileup --SVDPrefix resource/test/hapmap_3.3.b37.dat --Reference resource/test/chr20.fa.gz --NumPC 2)
+        COMMAND VerifyBamID --DisableSanityCheck --PileupFile resource/test/expected/result.Pileup --SVDPrefix resource/test/hapmap_3.3.b37.dat --Reference resource/test/chr20.fa.gz --NumPC 2 --Output result.myTest3)
 add_test(NAME myTest4
         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-        COMMAND sh -c "diff resource/test/expected/result.Ancestry result.Ancestry && rm result.Ancestry result.selfSM")
+        COMMAND sh -c "diff resource/test/expected/result.Ancestry result.myTest3.Ancestry && rm result.myTest3.Ancestry result.myTest3.selfSM")
+set_tests_properties(myTest4 PROPERTIES DEPENDS myTest3)
 add_test(NAME myTest5
         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-        COMMAND VerifyBamID --DisableSanityCheck --PileupFile resource/test/test.LongRead.pileup --SVDPrefix resource/test/hapmap_3.3.b37.dat --Reference resource/test/chr20.fa.gz --NumPC 2)
+        COMMAND VerifyBamID --DisableSanityCheck --PileupFile resource/test/test.LongRead.pileup --SVDPrefix resource/test/hapmap_3.3.b37.dat --Reference resource/test/chr20.fa.gz --NumPC 2 --Output result.myTest5)
 add_test(NAME myTest6
         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-        COMMAND sh -c "diff resource/test/expected/test.LongRead.pileup.Ancestry result.Ancestry && rm result.Ancestry result.selfSM")
+        COMMAND sh -c "diff resource/test/expected/test.LongRead.pileup.Ancestry result.myTest5.Ancestry && rm result.myTest5.Ancestry result.myTest5.selfSM")
+set_tests_properties(myTest6 PROPERTIES DEPENDS myTest5)
 
 # Each new test pair below uses its own --Output prefix so tests can run in
 # parallel without racing on the shared "result.*" filenames, and the Diff

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -95,6 +95,38 @@ add_test(NAME myTest6
         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
         COMMAND sh -c "diff resource/test/expected/test.LongRead.pileup.Ancestry result.Ancestry && rm result.Ancestry result.selfSM")
 
+# Test WithinAncestry model (OptimizeHomo)
+add_test(NAME testWithinAncestryRun
+        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+        COMMAND VerifyBamID --DisableSanityCheck --BamFile resource/test/test.bam --SVDPrefix resource/test/hapmap_3.3.b37.dat --Reference resource/test/chr20.fa.gz --NumPC 2 --WithinAncestry)
+add_test(NAME testWithinAncestryDiff
+        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+        COMMAND sh -c "diff resource/test/expected/test.WithinAncestry.Ancestry result.Ancestry && rm result.Ancestry result.selfSM")
+
+# Test WithinAncestry + FixPC (OptimizeHomoFixedPC)
+add_test(NAME testWithinAncestryFixPCRun
+        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+        COMMAND VerifyBamID --DisableSanityCheck --BamFile resource/test/test.bam --SVDPrefix resource/test/hapmap_3.3.b37.dat --Reference resource/test/chr20.fa.gz --NumPC 2 --WithinAncestry --FixPC 0.034756:0.0193)
+add_test(NAME testWithinAncestryFixPCDiff
+        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+        COMMAND sh -c "diff resource/test/expected/test.WithinAncestry.FixPC.Ancestry result.Ancestry && rm result.Ancestry result.selfSM")
+
+# Test FixAlpha (OptimizeHomoFixedAlpha initial + OptimizeHeterFixedAlpha)
+add_test(NAME testFixAlphaRun
+        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+        COMMAND VerifyBamID --DisableSanityCheck --BamFile resource/test/test.bam --SVDPrefix resource/test/hapmap_3.3.b37.dat --Reference resource/test/chr20.fa.gz --NumPC 2 --FixAlpha 0.1)
+add_test(NAME testFixAlphaDiff
+        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+        COMMAND sh -c "diff resource/test/expected/test.FixAlpha.Ancestry result.Ancestry && rm result.Ancestry result.selfSM")
+
+# Test FixPC in BetweenAncestry mode (OptimizeHeterFixedPC)
+add_test(NAME testHeterFixPCRun
+        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+        COMMAND VerifyBamID --DisableSanityCheck --BamFile resource/test/test.bam --SVDPrefix resource/test/hapmap_3.3.b37.dat --Reference resource/test/chr20.fa.gz --NumPC 2 --FixPC 0.034756:0.0193)
+add_test(NAME testHeterFixPCDiff
+        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+        COMMAND sh -c "diff resource/test/expected/test.HeterFixPC.Ancestry result.Ancestry && rm result.Ancestry result.selfSM")
+
 #add_test( NAME myTestPlot
 #          WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
 #          COMMAND sh ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/run.plot.sh -i ${CMAKE_CURRENT_SOURCE_DIR}/resource/test/hapmap_3.3.b37.dat.V -o ${CMAKE_CURRENT_SOURCE_DIR}/resource/test/hapmap -r 1000g -g grey)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -95,37 +95,46 @@ add_test(NAME myTest6
         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
         COMMAND sh -c "diff resource/test/expected/test.LongRead.pileup.Ancestry result.Ancestry && rm result.Ancestry result.selfSM")
 
+# Each new test pair below uses its own --Output prefix so tests can run in
+# parallel without racing on the shared "result.*" filenames, and the Diff
+# test is marked as DEPENDS on its Run so CTest always sequences them
+# correctly regardless of scheduling.
+
 # Test WithinAncestry model (OptimizeHomo)
 add_test(NAME testWithinAncestryRun
         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-        COMMAND VerifyBamID --DisableSanityCheck --BamFile resource/test/test.bam --SVDPrefix resource/test/hapmap_3.3.b37.dat --Reference resource/test/chr20.fa.gz --NumPC 2 --WithinAncestry)
+        COMMAND VerifyBamID --DisableSanityCheck --BamFile resource/test/test.bam --SVDPrefix resource/test/hapmap_3.3.b37.dat --Reference resource/test/chr20.fa.gz --NumPC 2 --WithinAncestry --Output result.WithinAncestry)
 add_test(NAME testWithinAncestryDiff
         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-        COMMAND sh -c "diff resource/test/expected/test.WithinAncestry.Ancestry result.Ancestry && rm result.Ancestry result.selfSM")
+        COMMAND sh -c "diff resource/test/expected/test.WithinAncestry.Ancestry result.WithinAncestry.Ancestry && rm result.WithinAncestry.Ancestry result.WithinAncestry.selfSM")
+set_tests_properties(testWithinAncestryDiff PROPERTIES DEPENDS testWithinAncestryRun)
 
 # Test WithinAncestry + FixPC (OptimizeHomoFixedPC)
 add_test(NAME testWithinAncestryFixPCRun
         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-        COMMAND VerifyBamID --DisableSanityCheck --BamFile resource/test/test.bam --SVDPrefix resource/test/hapmap_3.3.b37.dat --Reference resource/test/chr20.fa.gz --NumPC 2 --WithinAncestry --FixPC 0.034756:0.0193)
+        COMMAND VerifyBamID --DisableSanityCheck --BamFile resource/test/test.bam --SVDPrefix resource/test/hapmap_3.3.b37.dat --Reference resource/test/chr20.fa.gz --NumPC 2 --WithinAncestry --FixPC 0.034756:0.0193 --Output result.WithinAncestryFixPC)
 add_test(NAME testWithinAncestryFixPCDiff
         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-        COMMAND sh -c "diff resource/test/expected/test.WithinAncestry.FixPC.Ancestry result.Ancestry && rm result.Ancestry result.selfSM")
+        COMMAND sh -c "diff resource/test/expected/test.WithinAncestry.FixPC.Ancestry result.WithinAncestryFixPC.Ancestry && rm result.WithinAncestryFixPC.Ancestry result.WithinAncestryFixPC.selfSM")
+set_tests_properties(testWithinAncestryFixPCDiff PROPERTIES DEPENDS testWithinAncestryFixPCRun)
 
 # Test FixAlpha (OptimizeHomoFixedAlpha initial + OptimizeHeterFixedAlpha)
 add_test(NAME testFixAlphaRun
         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-        COMMAND VerifyBamID --DisableSanityCheck --BamFile resource/test/test.bam --SVDPrefix resource/test/hapmap_3.3.b37.dat --Reference resource/test/chr20.fa.gz --NumPC 2 --FixAlpha 0.1)
+        COMMAND VerifyBamID --DisableSanityCheck --BamFile resource/test/test.bam --SVDPrefix resource/test/hapmap_3.3.b37.dat --Reference resource/test/chr20.fa.gz --NumPC 2 --FixAlpha 0.1 --Output result.FixAlpha)
 add_test(NAME testFixAlphaDiff
         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-        COMMAND sh -c "diff resource/test/expected/test.FixAlpha.Ancestry result.Ancestry && rm result.Ancestry result.selfSM")
+        COMMAND sh -c "diff resource/test/expected/test.FixAlpha.Ancestry result.FixAlpha.Ancestry && rm result.FixAlpha.Ancestry result.FixAlpha.selfSM")
+set_tests_properties(testFixAlphaDiff PROPERTIES DEPENDS testFixAlphaRun)
 
 # Test FixPC in BetweenAncestry mode (OptimizeHeterFixedPC)
 add_test(NAME testHeterFixPCRun
         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-        COMMAND VerifyBamID --DisableSanityCheck --BamFile resource/test/test.bam --SVDPrefix resource/test/hapmap_3.3.b37.dat --Reference resource/test/chr20.fa.gz --NumPC 2 --FixPC 0.034756:0.0193)
+        COMMAND VerifyBamID --DisableSanityCheck --BamFile resource/test/test.bam --SVDPrefix resource/test/hapmap_3.3.b37.dat --Reference resource/test/chr20.fa.gz --NumPC 2 --FixPC 0.034756:0.0193 --Output result.HeterFixPC)
 add_test(NAME testHeterFixPCDiff
         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-        COMMAND sh -c "diff resource/test/expected/test.HeterFixPC.Ancestry result.Ancestry && rm result.Ancestry result.selfSM")
+        COMMAND sh -c "diff resource/test/expected/test.HeterFixPC.Ancestry result.HeterFixPC.Ancestry && rm result.HeterFixPC.Ancestry result.HeterFixPC.selfSM")
+set_tests_properties(testHeterFixPCDiff PROPERTIES DEPENDS testHeterFixPCRun)
 
 #add_test( NAME myTestPlot
 #          WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}

--- a/ContaminationEstimator.cpp
+++ b/ContaminationEstimator.cpp
@@ -1,8 +1,28 @@
 #include "ContaminationEstimator.h"
+#include <chrono>
 #include <fstream>
 #include <sstream>
 #include <cmath>
 #include <algorithm>
+
+// Simple RAII timer that logs elapsed wall-clock time for a named phase.
+namespace {
+struct PhaseTimer {
+    std::string name;
+    std::chrono::steady_clock::time_point start;
+
+    explicit PhaseTimer(const std::string &phaseName)
+        : name(phaseName), start(std::chrono::steady_clock::now()) {
+        notice("  Starting phase: %s", name.c_str());
+    }
+
+    ~PhaseTimer() {
+        auto end = std::chrono::steady_clock::now();
+        double secs = std::chrono::duration<double>(end - start).count();
+        notice("  Finished phase: %s  [%.3f seconds]", name.c_str(), secs);
+    }
+};
+} // anonymous namespace
 
 ContaminationEstimator::ContaminationEstimator() {
 
@@ -29,45 +49,69 @@ ContaminationEstimator::ContaminationEstimator(int nPC, const char *bedFile, int
 int ContaminationEstimator::OptimizeLLK(const std::string &OutputPrefix) {
     AmoebaMinimizer myMinimizer;
 
-    fn.Initialize();
+    {
+        PhaseTimer t("Initialize likelihood");
+        fn.Initialize();
+    }
+
     if (!isHeter) {
         if (isPCFixed) {
             std::cout << "Estimation from OptimizeHomoFixedPC:" << std::endl;
+            PhaseTimer t("OptimizeHomoFixedPC");
             OptimizeHomoFixedPC(myMinimizer);
         } else if (isAlphaFixed) {
+            PhaseTimer t("OptimizeHomoFixedAlpha");
             OptimizeHomoFixedAlpha(myMinimizer);
         } else {
             std::cout << "Estimation from OptimizeHomo:" << std::endl;
+            PhaseTimer t("OptimizeHomo");
             OptimizeHomo(myMinimizer);
         }
     } else//contamination source from different population
     {
         if (isPCFixed) {
             std::cout << "Estimation from OptimizeHeterFixedPC:" << std::endl;
+            PhaseTimer t("OptimizeHeterFixedPC");
             OptimizeHeterFixedPC(myMinimizer);
         } else if (isAlphaFixed) {
             std::cout << "Estimation from OptimizeHeterFixedAlpha:" << std::endl;
-            isHeter = false;
-            OptimizeHomoFixedAlpha(myMinimizer);
-            PC[1] = PC[0];
-            fn.globalPC2 = fn.globalPC;
-            isHeter = true;
-            OptimizeHeterFixedAlpha(myMinimizer);
+            {
+                PhaseTimer t("OptimizeHomoFixedAlpha (initial)");
+                isHeter = false;
+                OptimizeHomoFixedAlpha(myMinimizer);
+                PC[1] = PC[0];
+                fn.globalPC2 = fn.globalPC;
+                isHeter = true;
+            }
+            {
+                PhaseTimer t("OptimizeHeterFixedAlpha");
+                OptimizeHeterFixedAlpha(myMinimizer);
+            }
         } else {
             std::cout << "Estimation from OptimizeHeter:" << std::endl;
-            isHeter = false;
-            OptimizeHomo(myMinimizer);
-            PC[1] = PC[0];
-            fn.globalPC2 = fn.globalPC;
-            isHeter = true;
-            OptimizeHeter(myMinimizer);
+            {
+                PhaseTimer t("OptimizeHomo (initial)");
+                isHeter = false;
+                OptimizeHomo(myMinimizer);
+                PC[1] = PC[0];
+                fn.globalPC2 = fn.globalPC;
+                isHeter = true;
+            }
+            {
+                PhaseTimer t("OptimizeHeter");
+                OptimizeHeter(myMinimizer);
+            }
         }
         if (fn.globalAlpha >= 0.5) {
             std::swap(fn.globalPC[0], fn.globalPC2[0]);
             std::swap(fn.globalPC[1], fn.globalPC2[1]);
         }
     }
-    fn.CalculateLLK0();
+
+    {
+        PhaseTimer t("Calculate null-model LLK");
+        fn.CalculateLLK0();
+    }
     std::cout << "Contaminating Sample ";
     for (int i = 0; i < numPC; ++i) {
         std::cout << "PC" << i + 1 << ":" << fn.globalPC[i] << "\t";

--- a/ContaminationEstimator.cpp
+++ b/ContaminationEstimator.cpp
@@ -46,8 +46,45 @@ ContaminationEstimator::ContaminationEstimator(int nPC, const char *bedFile, int
 
 }
 
+// Resolve per-marker data that is constant across all optimization iterations.
+//
+// During optimization, ComputeMixLLKs is called tens of thousands of times.
+// Each call iterates over all markers and previously performed nested hash map
+// lookups (posIndex[chr][pos], ChooseBed[chr][pos], knownAF[chr][pos]) on every
+// iteration.  Since none of these values change between calls, we resolve them
+// once here into a flat vector indexed by marker ordinal.
+//
+// For markers not present in the viewer (e.g. the BAM had no reads at that
+// position), baseInfoIndex is set to -1 so ComputeMixLLKs can skip them with
+// a single integer comparison instead of two hash lookups.
+//
+// Must be called after data loading (ReadBam/ReadPileup) and before the
+// optimization loop in OptimizeLLK.
+void ContaminationEstimator::BuildResolvedMarkers() {
+    resolvedMarkers.resize(NumMarker);
+    for (size_t i = 0; i < NumMarker; ++i) {
+        const std::string& chr = PosVec[i].first;
+        int pos = PosVec[i].second;
+        ResolvedMarker& rm = resolvedMarkers[i];
+
+        auto chrIt = viewer.posIndex.find(chr);
+        if (chrIt == viewer.posIndex.end()) { rm.baseInfoIndex = -1; continue; }
+        auto posIt = chrIt->second.find(pos);
+        if (posIt == chrIt->second.end()) { rm.baseInfoIndex = -1; continue; }
+
+        rm.baseInfoIndex = posIt->second;
+        rm.altBase = ChooseBed[chr][pos].second;
+        rm.knownAFValue = 0.0;
+        if (isAFknown) {
+            rm.knownAFValue = knownAF[chr][pos];
+        }
+    }
+}
+
 int ContaminationEstimator::OptimizeLLK(const std::string &OutputPrefix) {
     AmoebaMinimizer myMinimizer;
+
+    BuildResolvedMarkers();
 
     {
         PhaseTimer t("Initialize likelihood");

--- a/ContaminationEstimator.cpp
+++ b/ContaminationEstimator.cpp
@@ -24,6 +24,10 @@ struct PhaseTimer {
 };
 } // anonymous namespace
 
+// Out-of-class definition required in C++11 for static constexpr members that
+// are ODR-used.  Without this, GCC's linker reports an undefined reference.
+constexpr double ContaminationEstimator::FullLLKFunc::COND_LK[2][3][3];
+
 ContaminationEstimator::ContaminationEstimator() {
 
 }

--- a/ContaminationEstimator.h
+++ b/ContaminationEstimator.h
@@ -56,6 +56,20 @@ public:
         return pow(10.0, x / -10.0);
     }
 
+    // Precomputed Phred error probabilities for quality scores 0-93 (after ASCII-33 offset).
+    // Avoids repeated pow() calls in the hot loop.
+    static const double* getPhredTable() {
+        static double table[94];
+        static bool initialized = false;
+        if (!initialized) {
+            for (int i = 0; i < 94; ++i) {
+                table[i] = pow(10.0, i / -10.0);
+            }
+            initialized = true;
+        }
+        return table;
+    }
+
     class FullLLKFunc : public VectorFunc {
     public:
         double min_af;
@@ -70,6 +84,7 @@ public:
         std::vector<double> globalPC2;//best result holder
         double globalAlpha;//best result holder
         const char *Base;
+        const double *phredTable;
 
         FullLLKFunc() {
             FullLLKFunc::Base = "actg";
@@ -78,6 +93,7 @@ public:
             llk1 = 0;
             ptr = nullptr;
             fixAlpha = 0;
+            phredTable = getPhredTable();
             std::cerr << "Initialize from FullLLKFunc()" << std::endl;
 
         }
@@ -91,6 +107,7 @@ public:
             ptr = contPtr;
             fixAlpha = 0.;
             globalAlpha = 0.;
+            phredTable = getPhredTable();
             std::cerr << "Initialize from FullLLKFunc(int dim, ContaminationEstimator* contPtr)" << std::endl;
         }
 
@@ -258,19 +275,26 @@ public:
 
                 char altBase = ptr->ChooseBed[chr][pos].second;
 
+                // Precompute per-base phred error probabilities so they are
+                // looked up once per base rather than 9x (once per genotype pair).
+                const int depth = tmpBase.size();
+                std::vector<double> phredErr(depth);
+                std::vector<double> phredNoErr(depth);
+                for (int j = 0; j < depth; ++j) {
+                    phredErr[j] = phredTable[static_cast<unsigned char>(tmpQual[j]) - 33];
+                    phredNoErr[j] = 1.0 - phredErr[j];
+                }
+
                 for (int geno1 = 0; geno1 < 3; ++geno1)
                     for (int geno2 = 0; geno2 < 3; ++geno2) {
                         double baseLK(0);
-                        for (int j = 0; j < tmpBase.size(); ++j) {
+                        for (int j = 0; j < depth; ++j) {
                             baseLK += log((alpha * getConditionalBaseLK(tmpBase[j], geno1, altBase, 1) +
                                            (1. - alpha) * getConditionalBaseLK(tmpBase[j], geno2, altBase, 1)) *
-                                          Phred(tmpQual[j] - 33)
+                                          phredErr[j]
                                           + (alpha * getConditionalBaseLK(tmpBase[j], geno1, altBase, 0) +
                                              (1. - alpha) * getConditionalBaseLK(tmpBase[j], geno2, altBase, 0)) *
-                                            (1 - Phred(tmpQual[j] - 33)));
-//                            std::cerr <<i<<"th marker\t"<<tmpBase[j]<<"\t"<<tmpQual[j]<<"\t"<<altBase<<"\tlocalAlpha:"<<localAlpha<<"\tgeno1:"<<geno1<<"\tgeno2:"<<geno2
-//                            <<"\tgetConditionalBaseLK1:"<<getConditionalBaseLK(tmpBase[j], geno1, altBase, 1)<<"\t"<< getConditionalBaseLK(tmpBase[j], geno2, altBase, 1)<<"\tPhred:"<<Phred(tmpQual[j] - 33)
-//                            <<"\tgetConditionalBaseLK0:"<<getConditionalBaseLK(tmpBase[j], geno1, altBase, 0)<<"\t"<<getConditionalBaseLK(tmpBase[j], geno2, altBase, 0)<< std::endl;
+                                            phredNoErr[j]);
                         }
                         markerLK += exp(baseLK) * GF[geno1] * GF2[geno2];
                     }

--- a/ContaminationEstimator.h
+++ b/ContaminationEstimator.h
@@ -221,8 +221,8 @@ public:
                     continue;
                 }
 
-                std::vector<char> tmpBase = ptr->viewer.GetBaseInfoAt(chr, pos);
-                std::vector<char> tmpQual = ptr->viewer.GetQualInfoAt(chr, pos);
+                const std::vector<char>& tmpBase = ptr->viewer.GetBaseInfoAt(chr, pos);
+                const std::vector<char>& tmpQual = ptr->viewer.GetQualInfoAt(chr, pos);
 
                 if (tmpBase.size() == 0) continue;
 

--- a/ContaminationEstimator.h
+++ b/ContaminationEstimator.h
@@ -191,6 +191,40 @@ public:
         inline double
         ComputeMixLLKs(const std::vector<double> &tPC1, const std::vector<double> &tPC2, const double alpha) {
 
+            // Precompute log-likelihood contributions for every possible combination
+            // of (base_class, quality_score, g1, g2).
+            //
+            // The per-base log-likelihood under a genotype pair (g1, g2) is:
+            //   log( [alpha*P(b|g1,err) + (1-alpha)*P(b|g2,err)] * P(err)
+            //      + [alpha*P(b|g1,ok)  + (1-alpha)*P(b|g2,ok) ] * P(ok) )
+            //
+            // Within a single call alpha is constant, and the remaining inputs are
+            // all discrete with small domains:
+            //   - base_class (ref/alt/other):  3 values — determines P(b|g,err/ok)
+            //   - quality score (Phred 0-93): 94 values — determines P(err), P(ok)
+            //   - g1, g2 (genotype pair):      3 x 3 = 9 combinations
+            //
+            // Total: 3 x 94 x 9 = 2,538 entries.  Building this table costs 2,538
+            // log() calls, but replaces millions (depth x markers x 9) in the inner
+            // loop — typically a ~500x reduction in log() calls.
+            const double oneMinusAlpha = 1.0 - alpha;
+            double logLkTable[3][94][3][3];
+            for (int bc = 0; bc < 3; ++bc) {
+                const double lkErr[3]   = { COND_LK[1][0][bc], COND_LK[1][1][bc], COND_LK[1][2][bc] };
+                const double lkNoErr[3] = { COND_LK[0][0][bc], COND_LK[0][1][bc], COND_LK[0][2][bc] };
+                for (int q = 0; q < 94; ++q) {
+                    const double pErr   = phredTable[q];
+                    const double pNoErr = 1.0 - pErr;
+                    for (int g1 = 0; g1 < 3; ++g1) {
+                        for (int g2 = 0; g2 < 3; ++g2) {
+                            double val = (alpha * lkErr[g1] + oneMinusAlpha * lkErr[g2]) * pErr
+                                       + (alpha * lkNoErr[g1] + oneMinusAlpha * lkNoErr[g2]) * pNoErr;
+                            logLkTable[bc][q][g1][g2] = log(val);
+                        }
+                    }
+                }
+            }
+
             double sumLLK(0);
 #ifdef _OPENMP
             omp_set_num_threads(ptr->numThread);
@@ -238,42 +272,23 @@ public:
 
                 char altBase = rm.altBase;
 
-                // For each observed base at this marker, compute its contribution to the
-                // log-likelihood under all 9 genotype-pair combinations (g1, g2) where
-                // g1 is the contaminating sample's genotype and g2 is the intended sample's.
+                // Accumulate log-likelihoods across all observed bases at this marker.
+                // For each base we classify it (ref/alt/other), extract its quality
+                // score, and use those two values to index into the precomputed
+                // logLkTable — one addition per genotype pair instead of a log() call.
                 //
-                // The likelihood of observing a base given a genotype pair is a mixture:
-                //   P(base | g1, g2, alpha) =
-                //       [alpha * P(base|g1,err) + (1-alpha) * P(base|g2,err)] * P(err)
-                //     + [alpha * P(base|g1,ok)  + (1-alpha) * P(base|g2,ok) ] * P(ok)
-                //
-                // where P(err) is the Phred-scaled base error probability and P(ok) = 1 - P(err).
-                // The conditional probabilities P(base|genotype,err/ok) depend only on whether
-                // the base is ref, alt, or other — looked up from the COND_LK table.
-                //
-                // baseLKAccum[g1][g2] accumulates sum-of-log-likelihoods across all bases,
-                // which equals the log of the product of per-base likelihoods.
+                // baseLKAccum[g1][g2] = sum_j log P(base_j | g1, g2, alpha)
+                //                     = log product_j P(base_j | g1, g2, alpha)
                 const int depth = tmpBase.size();
                 double baseLKAccum[3][3] = {};
 
                 for (int j = 0; j < depth; ++j) {
-                    // Classify base once: ref (./,), alt, or other
                     const int bc = classifyBase(tmpBase[j], altBase);
-                    const double pErr   = phredTable[static_cast<unsigned char>(tmpQual[j]) - 33];
-                    const double pNoErr = 1.0 - pErr;
+                    const int q  = static_cast<unsigned char>(tmpQual[j]) - 33;
 
-                    // Look up conditional likelihoods for each genotype (0=hom-ref, 1=het, 2=hom-alt)
-                    const double lkErr[3]   = { COND_LK[1][0][bc], COND_LK[1][1][bc], COND_LK[1][2][bc] };
-                    const double lkNoErr[3] = { COND_LK[0][0][bc], COND_LK[0][1][bc], COND_LK[0][2][bc] };
-
-                    // Accumulate log-likelihood for all 9 genotype-pair combinations
-                    for (int g1 = 0; g1 < 3; ++g1) {
-                        for (int g2 = 0; g2 < 3; ++g2) {
-                            double val = (alpha * lkErr[g1] + (1.0 - alpha) * lkErr[g2]) * pErr
-                                       + (alpha * lkNoErr[g1] + (1.0 - alpha) * lkNoErr[g2]) * pNoErr;
-                            baseLKAccum[g1][g2] += log(val);
-                        }
-                    }
+                    for (int g1 = 0; g1 < 3; ++g1)
+                        for (int g2 = 0; g2 < 3; ++g2)
+                            baseLKAccum[g1][g2] += logLkTable[bc][q][g1][g2];
                 }
 
                 // Marginalize over genotype pairs, weighting each by its prior

--- a/ContaminationEstimator.h
+++ b/ContaminationEstimator.h
@@ -198,16 +198,11 @@ public:
 #endif
             for (size_t i = 0; i < ptr->NumMarker; ++i) {
 
-                std::string chr = ptr->PosVec[i].first;
-                int pos = ptr->PosVec[i].second;
-                if (ptr->viewer.posIndex.find(chr) == ptr->viewer.posIndex.end()) {
-                    continue;
-                } else if (ptr->viewer.posIndex[chr].find(pos) == ptr->viewer.posIndex[chr].end()) {
-                    continue;
-                }
+                const ContaminationEstimator::ResolvedMarker& rm = ptr->resolvedMarkers[i];
+                if (rm.baseInfoIndex < 0) continue;
 
-                const std::vector<char>& tmpBase = ptr->viewer.GetBaseInfoAt(chr, pos);
-                const std::vector<char>& tmpQual = ptr->viewer.GetQualInfoAt(chr, pos);
+                const std::vector<char>& tmpBase = ptr->viewer.baseInfo[rm.baseInfoIndex];
+                const std::vector<char>& tmpQual = ptr->viewer.qualInfo[rm.baseInfoIndex];
 
                 if (tmpBase.size() == 0) continue;
 
@@ -217,7 +212,7 @@ public:
                     continue;
 
                 if (ptr->isAFknown) {
-                    ptr->AFs[i] = ptr->AF2s[i] = ptr->knownAF[chr][pos];
+                    ptr->AFs[i] = ptr->AF2s[i] = rm.knownAFValue;
                 } else {
                     ptr->AFs[i] = 0.;
                     for (int k = 0; k < tPC1.size(); ++k) {
@@ -241,7 +236,7 @@ public:
                 InitialGF(ptr->AFs[i], GF);
                 InitialGF(ptr->AF2s[i], GF2);
 
-                char altBase = ptr->ChooseBed[chr][pos].second;
+                char altBase = rm.altBase;
 
                 // For each observed base at this marker, compute its contribution to the
                 // log-likelihood under all 9 genotype-pair combinations (g1, g2) where
@@ -443,6 +438,16 @@ public:
     std::vector<region_t> BedVec;//serialized BED info, convenient for bam reading
     std::vector<std::pair<std::string, int> > PosVec;
 
+    // Per-marker data resolved once by BuildResolvedMarkers() so that
+    // ComputeMixLLKs can use flat vector indexing instead of repeated
+    // nested hash map lookups (posIndex, ChooseBed, knownAF).
+    struct ResolvedMarker {
+        int baseInfoIndex;   // index into viewer.baseInfo/qualInfo, or -1 if marker absent
+        char altBase;        // alternate allele from ChooseBed
+        double knownAFValue; // allele frequency from knownAF (0.0 if !isAFknown)
+    };
+    std::vector<ResolvedMarker> resolvedMarkers;
+
     ContaminationEstimator();
 
     ContaminationEstimator(int nPC, const char *bedFile, int nThread, double ep);
@@ -491,6 +496,8 @@ public:
                          const std::string &ReadGroup);
     */
     int ReadSVDMatrix(const std::string &UDpath, const std::string &PCpath, const std::string &Mean);
+
+    void BuildResolvedMarkers();
 
     /*
     int FromBamtoPileup();

--- a/ContaminationEstimator.h
+++ b/ContaminationEstimator.h
@@ -156,60 +156,28 @@ public:
             return Base[maxIndex];
         }
 
-        inline double getConditionalBaseLK(char base, int genotype, char altBase, bool is_error) {
-            if (!is_error) {
-                if (genotype == 0) {
-                    if (base == '.' || base == ',') {
-                        return 1;
-                    } else
-                        return 0;
-                } else if (genotype == 1) {
-                    if (base == '.' || base == ',') {
-                        return 0.5;
-                    } else if (toupper(base) == toupper(altBase)) {
-                        return 0.5;
-                    } else
-                        return 0;
-                } else if (genotype == 2) {
-                    if (toupper(base) == toupper(altBase)) {
-                        return 1;
-                    } else
-                        return 0;
-                } else {
-                    std::cerr << "genotype error!" << std::endl;
-                    exit(EXIT_FAILURE);
-                }
-            } else {
-                if (genotype == 0) {
-                    if (base == '.' || base == ',') {
-                        return 0;
-                    } else if (toupper(base) == toupper(altBase)) {
-                        return 1. / 3.;
-                    } else
-                        return 2. / 3.;
-                } else if (genotype == 1) {
-                    if (base == '.' || base == ',') {
-                        return 1. / 6.;
-                    } else if (toupper(base) == toupper(altBase)) {
-                        return 1. / 6.;
-                    } else
-                        return 2. / 3.;
-                } else if (genotype == 2) {
-                    if (base == '.' || base == ',') {
-                        return 1. / 3.;
-                    }
-                    if (toupper(base) == toupper(altBase)) {
-                        return 0;
-                    } else
-                        return 2. / 3.;
-                } else {
-                    std::cerr << "genotype error!" << std::endl;
-                    exit(EXIT_FAILURE);
-                }
+        // Conditional base likelihood lookup table indexed by [is_error][genotype][base_class].
+        // base_class: 0=ref (./,), 1=alt (matches altBase), 2=other
+        static constexpr double COND_LK[2][3][3] = {
+            // is_error = 0 (no sequencing error)
+            {
+                /* geno 0 (hom ref) */ {1.0,     0.0,     0.0},
+                /* geno 1 (het)     */ {0.5,     0.5,     0.0},
+                /* geno 2 (hom alt) */ {0.0,     1.0,     0.0},
+            },
+            // is_error = 1 (sequencing error)
+            {
+                /* geno 0 (hom ref) */ {0.0,     1.0/3.0, 2.0/3.0},
+                /* geno 1 (het)     */ {1.0/6.0, 1.0/6.0, 2.0/3.0},
+                /* geno 2 (hom alt) */ {1.0/3.0, 0.0,     2.0/3.0},
+            },
+        };
 
-            }
-
-
+        // Classify a base as ref (0), alt (1), or other (2).
+        static inline int classifyBase(char base, char altBase) {
+            if (base == '.' || base == ',') return 0;
+            if (toupper(base) == toupper(altBase)) return 1;
+            return 2;
         }
 
         void InitialGF(double AF, double *GF) const {
@@ -275,29 +243,49 @@ public:
 
                 char altBase = ptr->ChooseBed[chr][pos].second;
 
-                // Precompute per-base phred error probabilities so they are
-                // looked up once per base rather than 9x (once per genotype pair).
+                // For each observed base at this marker, compute its contribution to the
+                // log-likelihood under all 9 genotype-pair combinations (g1, g2) where
+                // g1 is the contaminating sample's genotype and g2 is the intended sample's.
+                //
+                // The likelihood of observing a base given a genotype pair is a mixture:
+                //   P(base | g1, g2, alpha) =
+                //       [alpha * P(base|g1,err) + (1-alpha) * P(base|g2,err)] * P(err)
+                //     + [alpha * P(base|g1,ok)  + (1-alpha) * P(base|g2,ok) ] * P(ok)
+                //
+                // where P(err) is the Phred-scaled base error probability and P(ok) = 1 - P(err).
+                // The conditional probabilities P(base|genotype,err/ok) depend only on whether
+                // the base is ref, alt, or other — looked up from the COND_LK table.
+                //
+                // baseLKAccum[g1][g2] accumulates sum-of-log-likelihoods across all bases,
+                // which equals the log of the product of per-base likelihoods.
                 const int depth = tmpBase.size();
-                std::vector<double> phredErr(depth);
-                std::vector<double> phredNoErr(depth);
+                double baseLKAccum[3][3] = {};
+
                 for (int j = 0; j < depth; ++j) {
-                    phredErr[j] = phredTable[static_cast<unsigned char>(tmpQual[j]) - 33];
-                    phredNoErr[j] = 1.0 - phredErr[j];
+                    // Classify base once: ref (./,), alt, or other
+                    const int bc = classifyBase(tmpBase[j], altBase);
+                    const double pErr   = phredTable[static_cast<unsigned char>(tmpQual[j]) - 33];
+                    const double pNoErr = 1.0 - pErr;
+
+                    // Look up conditional likelihoods for each genotype (0=hom-ref, 1=het, 2=hom-alt)
+                    const double lkErr[3]   = { COND_LK[1][0][bc], COND_LK[1][1][bc], COND_LK[1][2][bc] };
+                    const double lkNoErr[3] = { COND_LK[0][0][bc], COND_LK[0][1][bc], COND_LK[0][2][bc] };
+
+                    // Accumulate log-likelihood for all 9 genotype-pair combinations
+                    for (int g1 = 0; g1 < 3; ++g1) {
+                        for (int g2 = 0; g2 < 3; ++g2) {
+                            double val = (alpha * lkErr[g1] + (1.0 - alpha) * lkErr[g2]) * pErr
+                                       + (alpha * lkNoErr[g1] + (1.0 - alpha) * lkNoErr[g2]) * pNoErr;
+                            baseLKAccum[g1][g2] += log(val);
+                        }
+                    }
                 }
 
-                for (int geno1 = 0; geno1 < 3; ++geno1)
-                    for (int geno2 = 0; geno2 < 3; ++geno2) {
-                        double baseLK(0);
-                        for (int j = 0; j < depth; ++j) {
-                            baseLK += log((alpha * getConditionalBaseLK(tmpBase[j], geno1, altBase, 1) +
-                                           (1. - alpha) * getConditionalBaseLK(tmpBase[j], geno2, altBase, 1)) *
-                                          phredErr[j]
-                                          + (alpha * getConditionalBaseLK(tmpBase[j], geno1, altBase, 0) +
-                                             (1. - alpha) * getConditionalBaseLK(tmpBase[j], geno2, altBase, 0)) *
-                                            phredNoErr[j]);
-                        }
-                        markerLK += exp(baseLK) * GF[geno1] * GF2[geno2];
-                    }
+                // Marginalize over genotype pairs, weighting each by its prior
+                // probability under Hardy-Weinberg (GF for contaminating, GF2 for intended).
+                for (int g1 = 0; g1 < 3; ++g1)
+                    for (int g2 = 0; g2 < 3; ++g2)
+                        markerLK += exp(baseLKAccum[g1][g2]) * GF[g1] * GF2[g2];
                 if (markerLK > 0)
                     sumLLK += log(markerLK);
             }

--- a/ContaminationEstimator.h
+++ b/ContaminationEstimator.h
@@ -24,6 +24,7 @@ SOFTWARE.
 #ifndef CONTAMINATIONESTIMATOR_H_
 #define CONTAMINATIONESTIMATOR_H_
 
+#include <array>
 #include <string>
 #include <unordered_map>
 //#include <tkDecls.h>
@@ -57,17 +58,19 @@ public:
     }
 
     // Precomputed Phred error probabilities for quality scores 0-93 (after ASCII-33 offset).
-    // Avoids repeated pow() calls in the hot loop.
+    // Avoids repeated pow() calls in the hot loop.  C++11 guarantees that
+    // initialization of a local static is thread-safe, so using an
+    // immediately-invoked lambda ensures the table is built exactly once even
+    // under concurrent first callers.
     static const double* getPhredTable() {
-        static double table[94];
-        static bool initialized = false;
-        if (!initialized) {
+        static const std::array<double, 94> table = []() {
+            std::array<double, 94> t{};
             for (int i = 0; i < 94; ++i) {
-                table[i] = pow(10.0, i / -10.0);
+                t[i] = pow(10.0, i / -10.0);
             }
-            initialized = true;
-        }
-        return table;
+            return t;
+        }();
+        return table.data();
     }
 
     class FullLLKFunc : public VectorFunc {
@@ -284,7 +287,15 @@ public:
 
                 for (int j = 0; j < depth; ++j) {
                     const int bc = classifyBase(tmpBase[j], altBase);
-                    const int q  = static_cast<unsigned char>(tmpQual[j]) - 33;
+                    // Clamp quality to [0, 93] before indexing the lookup
+                    // table.  BAM-derived qualities are guaranteed in-range,
+                    // but --PileupFile inputs are ASCII and may carry values
+                    // outside the expected Phred+33 window if the file is
+                    // malformed or uses a different encoding; clamping avoids
+                    // out-of-bounds access without rejecting the record.
+                    int q = static_cast<unsigned char>(tmpQual[j]) - 33;
+                    if (q < 0) q = 0;
+                    else if (q > 93) q = 93;
 
                     for (int g1 = 0; g1 < 3; ++g1)
                         for (int g2 = 0; g2 < 3; ++g2)

--- a/main.cpp
+++ b/main.cpp
@@ -20,6 +20,7 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
  */
+#include <chrono>
 #include <fstream>
 #include <iostream>
 #include <sstream>
@@ -34,6 +35,23 @@ SOFTWARE.
 #include "backward.hpp"
 
 #define VERSION "2.0.1"
+
+// Simple RAII timer that logs elapsed wall-clock time for a named phase.
+struct PhaseTimer {
+    std::string name;
+    std::chrono::steady_clock::time_point start;
+
+    explicit PhaseTimer(const std::string &phaseName)
+        : name(phaseName), start(std::chrono::steady_clock::now()) {
+        notice("Starting phase: %s", name.c_str());
+    }
+
+    ~PhaseTimer() {
+        auto end = std::chrono::steady_clock::now();
+        double secs = std::chrono::duration<double>(end - start).count();
+        notice("Finished phase: %s  [%.3f seconds]", name.c_str(), secs);
+    }
+};
 
 int execute(int argc, char **argv) {
 
@@ -289,13 +307,19 @@ int execute(int argc, char **argv) {
         Estimator.ReadAF(knownAF);
     }
 
-    Estimator.ReadSVDMatrix(UDPath, PCPath, MeanPath);
+    {
+        PhaseTimer t("Load SVD reference data");
+        Estimator.ReadSVDMatrix(UDPath, PCPath, MeanPath);
+    }
 
-    if(nfiles)
-      Estimator.ReadBam(BamFile.c_str(), RefPath.c_str(), BedPath.c_str(),
-                        &mplp);
-    else
-        Estimator.ReadPileup(PileupFile);
+    {
+        PhaseTimer t(nfiles ? "Read BAM/CRAM" : "Read pileup");
+        if(nfiles)
+          Estimator.ReadBam(BamFile.c_str(), RefPath.c_str(), BedPath.c_str(),
+                            &mplp);
+        else
+            Estimator.ReadPileup(PileupFile);
+    }
 
 
     if(outputPileup)
@@ -334,6 +358,7 @@ int execute(int argc, char **argv) {
     }
 
     if(!disableSanityCheck) {
+        PhaseTimer t("Marker sanity check");
         if (Estimator.IsSanityCheckOK())
             notice("Passing Marker Sanity Check...");
         else {
@@ -342,7 +367,10 @@ int execute(int argc, char **argv) {
         }
     }
 
-    Estimator.OptimizeLLK(outputPrefix);
+    {
+        PhaseTimer t("Optimize likelihood");
+        Estimator.OptimizeLLK(outputPrefix);
+    }
 
     {//output vb1 compatible result
         const char *headers = "#SEQ_ID\tRG\tCHIP_ID\t#SNPS\t#READS\tAVG_DP\tFREEMIX\tFREELK1\tFREELK0\tFREE_RH\tFREE_RA\tCHIPMIX\tCHIPLK1\tCHIPLK0\tCHIP_RH\tCHIP_RA\tDPREF\tRDPHET\tRDPALT";

--- a/resource/test/expected/test.FixAlpha.Ancestry
+++ b/resource/test/expected/test.FixAlpha.Ancestry
@@ -1,0 +1,3 @@
+PC	ContaminatingSample	IntendedSample
+1	0.313366	0.0373351
+2	-0.375399	0.0130314

--- a/resource/test/expected/test.HeterFixPC.Ancestry
+++ b/resource/test/expected/test.HeterFixPC.Ancestry
@@ -1,0 +1,3 @@
+PC	ContaminatingSample	IntendedSample
+1	1.04629	0.034756
+2	-1.20591	0.0193

--- a/resource/test/expected/test.WithinAncestry.Ancestry
+++ b/resource/test/expected/test.WithinAncestry.Ancestry
@@ -1,0 +1,3 @@
+PC	ContaminatingSample	IntendedSample
+1	0.0411796	0.0411796
+2	-0.00197399	-0.00197399

--- a/resource/test/expected/test.WithinAncestry.FixPC.Ancestry
+++ b/resource/test/expected/test.WithinAncestry.FixPC.Ancestry
@@ -1,0 +1,3 @@
+PC	ContaminatingSample	IntendedSample
+1	0.034756	0.034756
+2	0.0193	0.0193


### PR DESCRIPTION
Hi @Griffan - I've been running VerifyBamID2 on some fairly large panels (because my goal is to get to very low coverage), and spent some time working on the runtime of the process for calculating FREEMIX from a BAM file.  This is all work done in partnership with Claude.  I've done my best to organize this into atomic commits, with some additional logging and tests developed up front.  These changes to not alter the outputs at all for the tests or my benchmarking real-world test case with ~5x coverage of 14k markers.

Please feel free to push back on any of this that you don't like, or would like restructured, better documented, better tested etc.  But the end results are pretty compelling - I'm at ~20-fold speed up (i.e. 95% reduction) of the optimization/post BAM-reading phase  running on an aarch64 mac, and I expect that the results on x86 will be broadly similar.

### Summary

The Amoeba minimizer calls `ComputeMixLLKs()` up to 50,000 times during optimization, and each call iterates over every marker in the reference panel. As panels grow, this becomes the dominant cost. This PR applies a series of targeted optimizations to the inner loop of `ComputeMixLLKs()` — replacing expensive per-call computations with precomputed tables and eliminating redundant work — to achieve a **22x speedup** on the optimization phase with **bit-identical results** on all tests.

All optimizations exploit the same insight: the inputs to the inner loop are drawn from small discrete domains, so values that were being recomputed millions of times can instead be looked up from compact tables built once per call or once at startup.

### Benchmark

Measured on a 14K-marker feline panel, single-threaded (`--NumPC 5 --NumThread 1`), Release build:

| Commit | Description | Optimize (s) | vs Baseline |
|--------|-------------|--------------|-------------|
| — | **Baseline (before this PR)** | **198.5** | **—** |
| `cf01323` | Add phase timing instrumentation. RAII `PhaseTimer` logs start/end/duration to stderr for each major phase (SVD loading, BAM reading, sanity check, optimization sub-phases), providing the measurement infrastructure for all subsequent changes. | 198.5 | — |
| `2a45948` | Add tests for all six optimization code paths. Previously only the default BetweenAncestry path was tested. Adds tests for `--WithinAncestry`, `--WithinAncestry --FixPC`, `--FixAlpha`, and `--FixPC`, covering `OptimizeHomo`, `OptimizeHomoFixedPC`, `OptimizeHomoFixedAlpha`, `OptimizeHeterFixedPC`, and `OptimizeHeterFixedAlpha`. All use exact-diff validation against golden output files. | 198.5 | — |
| `f0e0367` | Use const references for base/quality vectors in the hot loop. `GetBaseInfoAt`/`GetQualInfoAt` return references, but the loop was assigning to value types, causing a deep copy per marker per call. Negligible runtime impact but corrects a wasteful pattern. | ~198 | ~0% |
| `b9e5c18` | Replace `Phred()` pow() calls with a precomputed 94-entry lookup table. Quality scores are discrete integers in [0, 93], so `pow(10.0, x/-10.0)` can be tabulated once at startup. Also hoists the lookup above the 3x3 genotype loop so each base's error probability is fetched once instead of 9 times. | 136.6 | **-31%** |
| `54f08db` | Replace `getConditionalBaseLK` (a 50-line branchy function called 36x per base) with a static `constexpr` 2x3x3 lookup table, and restructure the inner loop from genotype-outer/base-inner to base-outer/genotype-inner. Each base is now classified once (ref/alt/other), its 6 conditional likelihoods looked up from the table, and contributions accumulated into 9 genotype-pair accumulators — instead of processing each base 9 separate times. | 47.1 | **-76%** |
| `fef0d70` | Precompute resolved markers into a flat vector at startup, eliminating 4-6 nested `unordered_map` lookups per marker per `ComputeMixLLKs` call (posIndex, ChooseBed, knownAF). The hot loop now uses a single integer comparison to skip absent markers and direct array indexing for base/quality data. | 34.4 | **-83%** |
| `cc59c54` | Precompute a log-likelihood lookup table at the top of each `ComputeMixLLKs` call. Within a call, alpha is constant, so `log(val)` depends only on base class (3), quality score (94), and genotype pair (9) = 2,538 unique values. Building this table once replaces ~1.3M `log()` calls per invocation with table additions. | **9.1** | **-95%** |

### Key design decisions

- **Bit-identical results**: Every optimization produces the exact same floating-point output. Tests use binary `diff` against golden files with no tolerance — all 15 tests pass on every commit.
- **One concern per commit**: Each commit is independently buildable, testable, and benchmarkable. The commits were evaluated individually during development and only kept if they provided a clear benefit.
- **No algorithmic changes**: The mathematical model, convergence criteria, and optimizer (Amoeba/Nelder-Mead) are unchanged. All speedups come from avoiding redundant computation of values that can be precomputed or tabulated.

### Test plan

- [x] All 15 CTest tests pass (7 original + 8 new) with exact-diff validation
- [x] FREEMIX output identical to baseline on benchmark sample
- [x] Phase timing confirms optimization is no longer the bottleneck (9s optimization vs 29s BAM reading)
- [ ] CI passes on Linux (GCC) and macOS (Clang)
