### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,48 +1,62 @@
 # In this image we do not include the R-based plot scripts.
-FROM ubuntu:20.04 as build
+# In this image we do not include the R-based plot scripts.
+FROM ubuntu:20.04 AS build
 
 # Set noninterative mode
-ENV DEBIAN_FRONTEND noninteractive
-ENV LD_LIBRARY_PATH=/usr/local/lib/:$LD_LIBRARY_PATH
+ENV DEBIAN_FRONTEND=noninteractive
+ENV LD_LIBRARY_PATH="/usr/local/lib"
+
+ARG HTSLIB_VERSION=1.23.1
+ARG VERSION=v2.0.3
 
 # apt update and install build requirements
 RUN apt-get update \
      && apt-get install -y \
-        g++=4:9.3.0-1ubuntu2 \
-        cmake=3.16.3-1ubuntu1 \
+        build-essential \
+        cmake \
+        g++ \
         git \
         wget \
         libbz2-dev=1.0.8-2 \
-        libcurl4-openssl-dev=7.68.0-1ubuntu2.7 \
-        zlib1g-dev=1:1.2.11.dfsg-2ubuntu1.2 \
-        liblzma-dev=5.2.4-1ubuntu1
+        libcurl4-openssl-dev \
+        zlib1g-dev \
+        liblzma-dev
 
 # Compile htslib
 WORKDIR /deps
-RUN wget -q https://github.com/samtools/htslib/releases/download/1.11/htslib-1.11.tar.bz2 \
-    && tar -xf htslib-1.11.tar.bz2 \
-    && mv htslib-1.11 htslib
+RUN wget -q https://github.com/samtools/htslib/releases/download/${HTSLIB_VERSION}/htslib-${HTSLIB_VERSION}.tar.bz2 \
+    && tar -xf htslib-${HTSLIB_VERSION}.tar.bz2 \
+    && mv htslib-${HTSLIB_VERSION} htslib
+
 WORKDIR /deps/htslib
 RUN autoheader; autoconf; ./configure --prefix=/usr/local/ \
     && make && make install
 
-# Compile VerifyBamID. Version 2.0.1
+# Compile VerifyBamID. Version ${VERSION}
 WORKDIR /
-RUN git clone --depth 1 --branch 2.0.1 git://github.com/Griffan/VerifyBamID.git
+RUN git clone https://github.com/Griffan/VerifyBamID.git && \
+    cd VerifyBamID && \
+    git checkout ${VERSION}
 WORKDIR /VerifyBamID/build
-RUN  cmake .. \
-     && make \
-     && make test
+
+# -fsigned-char: VerifyBamID's genotype-missing sentinel relies on `char`
+# being signed (default on x86_64 but not on aarch64), which otherwise
+# breaks missing-genotype detection and fails testReadVcf.
+RUN cmake -DCMAKE_C_FLAGS=-fsigned-char -DCMAKE_CXX_FLAGS=-fsigned-char .. && \
+    make && \
+    make test
 
 # Final image
 FROM ubuntu:20.04
-ENV DEBIAN_FRONTEND noninteractive
+ENV DEBIAN_FRONTEND="noninteractive"
+
 RUN apt update && apt install -y \
-        libgomp1=10.3.0-1ubuntu1~20.04 \
-        libcurl4-openssl-dev=7.68.0-1ubuntu2.7 \
+        libgomp1 \
+        libcurl4-openssl-dev \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
 COPY --from=build /VerifyBamID/bin/VerifyBamID /usr/local/bin/
 COPY --from=build /usr/local/lib/ /usr/local/lib/
+
 CMD ["VerifyBamID"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,4 @@
 # In this image we do not include the R-based plot scripts.
-# In this image we do not include the R-based plot scripts.
 FROM ubuntu:20.04 AS build
 
 # Set noninterative mode

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ RUN apt-get update \
         g++ \
         git \
         wget \
-        libbz2-dev=1.0.8-2 \
+        libbz2-dev \
         libcurl4-openssl-dev \
         zlib1g-dev \
         liblzma-dev
@@ -33,9 +33,7 @@ RUN autoheader; autoconf; ./configure --prefix=/usr/local/ \
 
 # Compile VerifyBamID. Version ${VERSION}
 WORKDIR /
-RUN git clone https://github.com/Griffan/VerifyBamID.git && \
-    cd VerifyBamID && \
-    git checkout ${VERSION}
+RUN git clone --depth 1 --branch ${VERSION} https://github.com/Griffan/VerifyBamID.git
 WORKDIR /VerifyBamID/build
 
 # -fsigned-char: VerifyBamID's genotype-missing sentinel relies on `char`


### PR DESCRIPTION
The Dockerfile in the main repo didn't build for me for a few reasons:
- the apt-get packages are hard coded to specific versions which aren't available in the main apt repositories any more
- the cmake command by default uses a signed character assumption which is true on linux, but not true on Mac. I was generating a test build on Mac (not the intended deployment environment), but `make test` was broken due to the signed char issue. The clarification to cmake here makes it platform agnostic

Additional:
- the targeted version of VerifyBamID is hard coded and doesn't line up with the latest tag
- the targeted HTSlib is very old, so this has been updated (including the 1.23 -> 1.23.1 vulnerability patch)