### PR TITLE
Add --MaxAlpha option to support contamination estimates above 50%

### DIFF
--- a/ContaminationEstimator.cpp
+++ b/ContaminationEstimator.cpp
@@ -38,6 +38,7 @@ ContaminationEstimator::~ContaminationEstimator() {
 ContaminationEstimator::ContaminationEstimator(int nPC, const char *bedFile, int nThread, double ep)
         :
         numPC(nPC), PC(2, std::vector<PCtype>(nPC, 0.)),muv(numPC,0), sdv(numPC,0), fn(nPC, this), numThread(nThread), epsilon(ep) {
+    maxAlpha = 0.5;
     isAFknown = false;
     isPCFixed = false;
     isAlphaFixed = false;
@@ -143,7 +144,7 @@ int ContaminationEstimator::OptimizeLLK(const std::string &OutputPrefix) {
                 OptimizeHeter(myMinimizer);
             }
         }
-        if (fn.globalAlpha >= 0.5) {
+        if (fn.globalAlpha >= maxAlpha) {
             std::swap(fn.globalPC[0], fn.globalPC2[0]);
             std::swap(fn.globalPC[1], fn.globalPC2[1]);
         }
@@ -163,7 +164,14 @@ int ContaminationEstimator::OptimizeLLK(const std::string &OutputPrefix) {
         std::cout << "PC" << i + 1 << ":" << fn.globalPC2[i] << "\t";
     }
     std::cout << std::endl;
-    std::cout << "FREEMIX(Alpha):" << (fn.globalAlpha < 0.5 ? fn.globalAlpha : (1 - fn.globalAlpha)) << std::endl;
+    double reportedAlpha = (fn.globalAlpha < maxAlpha) ? fn.globalAlpha : (1 - fn.globalAlpha);
+    std::cout << "FREEMIX(Alpha):" << reportedAlpha << std::endl;
+    if (fabs(reportedAlpha - maxAlpha) < 0.001 || fabs(fn.globalAlpha - maxAlpha) < 0.001) {
+        std::cerr << "WARNING: FREEMIX estimate (" << reportedAlpha
+                  << ") is at or near the --MaxAlpha boundary (" << maxAlpha
+                  << "). The true contamination may be higher. "
+                  << "Consider rerunning with a higher --MaxAlpha value." << std::endl;
+    }
 
     std::string fileName(OutputPrefix + ".Ancestry");
     std::ofstream fout(fileName);

--- a/ContaminationEstimator.h
+++ b/ContaminationEstimator.h
@@ -41,6 +41,7 @@ class ContaminationEstimator {
 public:
     bool isPCFixed;
     bool isAlphaFixed;
+    double maxAlpha;
     bool isAFknown;
     bool isHeter;
     bool isPileupInput;

--- a/main.cpp
+++ b/main.cpp
@@ -73,7 +73,7 @@ int execute(int argc, char **argv) {
                             "chr20,chr21,chr22");
 
   std::string fixPC("Empty");
-  double fixAlpha(-1.), epsilon(1e-8);
+  double fixAlpha(-1.), maxAlpha(0.5), epsilon(1e-8);
   bool withinAncestry(false), outputPileup(false), verbose(false),
       disableSanityCheck(false);
   int nfiles(0), seed(12345), nPC(2), nthread(4);
@@ -128,6 +128,11 @@ int execute(int argc, char **argv) {
       "[String] Input fixed PCs to estimate Alpha[format PC1:PC2:PC3...]")
   LONG_DOUBLE_PARAM("FixAlpha", &fixAlpha,
                     "[Double] Input fixed Alpha to estimate PC coordinates")
+  LONG_DOUBLE_PARAM("MaxAlpha", &maxAlpha,
+                    "[Double] Maximum alpha (contamination fraction) for "
+                    "optimization. Default 0.5. Set higher (e.g. 0.99) if "
+                    "contamination may exceed 50%% or if alpha converges to "
+                    "the boundary")
   LONG_STRING_PARAM("KnownAF", &knownAF,
                     "[String] known allele frequency file "
                     "(chr\tpos\tfreq)[Optional]")
@@ -284,6 +289,7 @@ int execute(int argc, char **argv) {
 
     Estimator.verbose=verbose;
     Estimator.seed = seed;
+    Estimator.maxAlpha = maxAlpha;
     Estimator.isHeter = !withinAncestry;
     Estimator.isSanityCheckDisabled = disableSanityCheck;
 
@@ -398,7 +404,7 @@ int execute(int argc, char **argv) {
             fout <<"NA";
         else fout<<Estimator.viewer.numBases;
         fout << "\t" << Estimator.viewer.avgDepth << "\t"
-             << ((Estimator.fn.globalAlpha < 0.5) ? Estimator.fn.globalAlpha : (1.f - Estimator.fn.globalAlpha)) << "\t"
+             << ((Estimator.fn.globalAlpha < Estimator.maxAlpha) ? Estimator.fn.globalAlpha : (1.0 - Estimator.fn.globalAlpha)) << "\t"
              << -Estimator.fn.llk1 << "\t" << -Estimator.fn.llk0 << "\t" << "NA\tNA\t"
              << "NA\tNA\tNA\tNA\tNA\t"
              << "NA\tNA\tNA" << std::endl;


### PR DESCRIPTION
## Problem

When running VerifyBamID2 on long-read (ONT) data, the hardcoded alpha boundary of 0.5 causes issues for samples with high contamination. If the true contamination exceeds 50%, the optimizer converges to the boundary and the reported FREEMIX value silently clips — there's no indication to the user that the estimate is unreliable.

We hit this running ~88k ONT samples through our QC pipeline, where a subset of samples consistently showed alpha pinned at exactly 0.5.

## Changes

- **New `--MaxAlpha` parameter** (default: 0.5, preserving current behavior) that controls the upper bound for contamination estimation. Users can set it higher (e.g. 0.99) when contamination may exceed 50%.
- **Boundary warning**: when the reported FREEMIX is within 0.001 of the MaxAlpha boundary, a stderr warning is emitted suggesting the user rerun with a higher value.
- Replaced the hardcoded 0.5 threshold in `ContaminationEstimator.cpp`, `ContaminationEstimator.h`, and `main.cpp` (`.selfSM` output) with the configurable `maxAlpha` member.
- Also fixed a minor implicit float narrowing (`1.f` → `1.0`) in the selfSM output line.

## Testing

- Verified default behavior is unchanged (MaxAlpha=0.5 produces identical output to the unpatched version).
- Tested with `--MaxAlpha 0.99` on samples where alpha was previously clipped — contamination estimates now extend past 0.5 and the boundary warning fires correctly.
- Confirmed warning triggers only when estimate is near the boundary.

## Backward compatibility

Fully backward-compatible: default MaxAlpha is 0.5, matching existing behavior. No changes to output format — only an additional optional stderr warning.