### PR TITLE
Add --Methylation mode for bisulfite/EM-seq contamination estimation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,4 +12,5 @@ cmake-build-release*
 VerifyBamID
 bin/TestGramSVD
 bin/TestReadVcf
+bin/TestMethylationModel
 *vcf.gz

--- a/.gitignore
+++ b/.gitignore
@@ -13,4 +13,7 @@ VerifyBamID
 bin/TestGramSVD
 bin/TestReadVcf
 bin/TestMethylationModel
+bin/MethylateTestBam
+resource/test/test.methyl.bam
+resource/test/test.methyl.bam.bai
 *vcf.gz

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,7 +63,7 @@ add_subdirectory(statgen)
 set(LIBSTATGEN_INCLUDE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/statgen")
 add_subdirectory(samtools)
 add_subdirectory(libVcf)
-set(SOURCE_FILES main.cpp SVDcalculator.cpp ContaminationEstimator.cpp MathGenMin.cpp MathGold.cpp Random.cpp SimplePileupViewer.cpp params.cpp )
+set(SOURCE_FILES main.cpp SVDcalculator.cpp ContaminationEstimator.cpp MathGenMin.cpp MathGold.cpp Random.cpp SimplePileupViewer.cpp MethylationModel.cpp params.cpp )
 include_directories(statgen ${HTS_INCLUDE_DIRS} samtools libVcf Eigen)
 add_executable(VerifyBamID ${SOURCE_FILES})
 
@@ -76,6 +76,10 @@ add_executable(TestGramSVD TestGramSVD.cpp SVDcalculator.cpp)
 target_include_directories(TestGramSVD PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
 target_link_libraries(TestGramSVD statgen Vcf ${HTS_LIBRARIES} samtools ${ZLIB} ${BZIP2} ${LZMA} ${CURLLIB})
 
+add_executable(TestMethylationModel TestMethylationModel.cpp MethylationModel.cpp)
+target_include_directories(TestMethylationModel PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
+target_link_libraries(TestMethylationModel ${HTS_LIBRARIES} ${ZLIB} ${BZIP2} ${LZMA} ${CURLLIB})
+
 enable_testing()
 add_test(NAME testReadVcf
         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
@@ -83,6 +87,9 @@ add_test(NAME testReadVcf
 add_test(NAME testGramSVD
         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
         COMMAND TestGramSVD)
+add_test(NAME testMethylationModel
+        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+        COMMAND TestMethylationModel)
 add_test(NAME myTest1
         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
         COMMAND VerifyBamID --DisableSanityCheck --BamFile resource/test/test.bam --SVDPrefix resource/test/hapmap_3.3.b37.dat --Reference resource/test/chr20.fa.gz --NumPC 2 --Output result.myTest1)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -172,7 +172,7 @@ add_test(NAME testMethylationRun
 set_tests_properties(testMethylationRun PROPERTIES DEPENDS methylMakeBam)
 add_test(NAME testMethylationDiff
         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-        COMMAND sh -c "diff resource/test/expected/result.methyl.Ancestry result.Methylation.Ancestry && rm result.Methylation.Ancestry result.Methylation.selfSM")
+        COMMAND sh -c "diff resource/test/expected/result.methyl.Ancestry result.Methylation.Ancestry && rm result.Methylation.Ancestry result.Methylation.selfSM resource/test/test.methyl.bam resource/test/test.methyl.bam.bai")
 set_tests_properties(testMethylationDiff PROPERTIES DEPENDS testMethylationRun)
 
 #add_test( NAME myTestPlot

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -80,6 +80,12 @@ add_executable(TestMethylationModel TestMethylationModel.cpp MethylationModel.cp
 target_include_directories(TestMethylationModel PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
 target_link_libraries(TestMethylationModel ${HTS_LIBRARIES} ${ZLIB} ${BZIP2} ${LZMA} ${CURLLIB})
 
+# Test-only helper: synthesizes a directional methyl-seq BAM from an aligned BAM
+# so the end-to-end --Methylation test can generate its input programmatically.
+add_executable(MethylateTestBam MethylateTestBam.cpp)
+target_include_directories(MethylateTestBam PRIVATE ${HTS_INCLUDE_DIRS})
+target_link_libraries(MethylateTestBam ${HTS_LIBRARIES} ${ZLIB} ${BZIP2} ${LZMA} ${CURLLIB})
+
 enable_testing()
 add_test(NAME testReadVcf
         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
@@ -152,6 +158,22 @@ add_test(NAME testHeterFixPCDiff
         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
         COMMAND sh -c "diff resource/test/expected/test.HeterFixPC.Ancestry result.HeterFixPC.Ancestry && rm result.HeterFixPC.Ancestry result.HeterFixPC.selfSM")
 set_tests_properties(testHeterFixPCDiff PROPERTIES DEPENDS testHeterFixPCRun)
+
+# End-to-end --Methylation test. The methyl-seq input is synthesized from the
+# existing test.bam at test time (no committed test data): MethylateTestBam
+# applies the directional bisulfite conversion, then VerifyBamID --Methylation
+# is diffed against a golden Ancestry file. Chained via DEPENDS.
+add_test(NAME methylMakeBam
+        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+        COMMAND MethylateTestBam resource/test/test.bam resource/test/test.methyl.bam)
+add_test(NAME testMethylationRun
+        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+        COMMAND VerifyBamID --DisableSanityCheck --Methylation --BamFile resource/test/test.methyl.bam --SVDPrefix resource/test/hapmap_3.3.b37.dat --Reference resource/test/chr20.fa.gz --NumPC 2 --Output result.Methylation)
+set_tests_properties(testMethylationRun PROPERTIES DEPENDS methylMakeBam)
+add_test(NAME testMethylationDiff
+        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+        COMMAND sh -c "diff resource/test/expected/result.methyl.Ancestry result.Methylation.Ancestry && rm result.Methylation.Ancestry result.Methylation.selfSM")
+set_tests_properties(testMethylationDiff PROPERTIES DEPENDS testMethylationRun)
 
 #add_test( NAME myTestPlot
 #          WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}

--- a/ContaminationEstimator.cpp
+++ b/ContaminationEstimator.cpp
@@ -488,7 +488,7 @@ int ContaminationEstimator::ReadAF(const std::string &path) {
 
 int ContaminationEstimator::ReadBam(const char *bamFile, const char *faiFile,
                                     const char *bedFile, mplp_conf_t *mplpPtr) {
-  viewer = SimplePileupViewer(&BedVec, bamFile, faiFile, bedFile, mplpPtr, 1);
+  viewer = SimplePileupViewer(&BedVec, bamFile, faiFile, bedFile, mplpPtr, ChooseBed, 1);
   return 0;
 }
 

--- a/MethylateTestBam.cpp
+++ b/MethylateTestBam.cpp
@@ -60,6 +60,13 @@ int main(int argc, char **argv) {
             if (top && base == C)      set_base(seq, i, T);
             else if (!top && base == G) set_base(seq, i, A);
         }
+        // MD spells out the reference base at every mismatch, so it is
+        // inconsistent once SEQ changes -- drop it. NM is left as-is: a
+        // methyl-aware aligner would not count the introduced C->T/G->A
+        // conversions as mismatches, so the original edit distance stays a
+        // defensible value. (VerifyBamID uses neither; it re-derives mismatches
+        // from SEQ against the reference.)
+        if (uint8_t *md = bam_aux_get(b, "MD")) bam_aux_del(b, md);
         if (sam_write1(out, hdr, b) < 0) { fprintf(stderr, "write error\n"); return 1; }
     }
     bam_destroy1(b);

--- a/MethylateTestBam.cpp
+++ b/MethylateTestBam.cpp
@@ -1,0 +1,72 @@
+// Test helper (not shipped): turn an aligned BAM into a directional
+// methyl-seq BAM by applying the bisulfite conversion that methylation mode is
+// designed to handle. In genome-forward coordinates (the orientation htslib
+// stores SEQ in), a read from the "top"/CT strand has every C read as T and a
+// read from the "bottom"/GA strand has every G read as A. Converting *every*
+// applicable base simulates fully unmethylated DNA -- the maximal-conversion
+// case -- and is deterministic, so the resulting VerifyBamID --Methylation
+// output can be diffed against a committed golden file.
+//
+// The strand rule below is written out explicitly here, independently of
+// MethylationModel, so the end-to-end test genuinely exercises that code path
+// rather than tautologically agreeing with it.
+//
+// Usage: MethylateTestBam <in.bam> <out.bam>   (writes out.bam and out.bam.bai)
+
+#include "htslib/sam.h"
+
+#include <cstdint>
+#include <cstdio>
+
+// Set the 4-bit base code at query position i in a packed SEQ array, matching
+// htslib's bam_seqi() nibble layout (even i -> high nibble, odd i -> low).
+static inline void set_base(uint8_t *seq, int i, int code) {
+    int shift = (~i & 1) << 2;
+    seq[i >> 1] = (seq[i >> 1] & ~(0xf << shift)) | (code << shift);
+}
+
+int main(int argc, char **argv) {
+    if (argc != 3) {
+        fprintf(stderr, "usage: %s <in.bam> <out.bam>\n", argv[0]);
+        return 2;
+    }
+    samFile *in = sam_open(argv[1], "r");
+    if (!in) { fprintf(stderr, "cannot open %s\n", argv[1]); return 1; }
+    sam_hdr_t *hdr = sam_hdr_read(in);
+    if (!hdr) { fprintf(stderr, "cannot read header of %s\n", argv[1]); return 1; }
+    samFile *out = sam_open(argv[2], "wb");
+    if (!out || sam_hdr_write(out, hdr) < 0) {
+        fprintf(stderr, "cannot write %s\n", argv[2]); return 1;
+    }
+
+    // seq_nt16 base codes: A=1, C=2, G=4, T=8.
+    const int A = 1, C = 2, G = 4, T = 8;
+    bam1_t *b = bam_init1();
+    int ret;
+    while ((ret = sam_read1(in, hdr, b)) >= 0) {
+        const uint16_t f = b->core.flag;
+        const bool paired = f & BAM_FPAIRED;
+        const bool rev    = f & BAM_FREVERSE;
+        const bool read1  = f & BAM_FREAD1;
+        const bool mrev   = f & BAM_FMREVERSE;
+        // Directional convention: the conversion channel is the strand read 1
+        // aligned to. Read 1 uses its own orientation; read 2 uses its mate's.
+        const bool read1Reverse = paired ? (read1 ? rev : mrev) : rev;
+        const bool top = !read1Reverse;   // top => CT-converted, else GA-converted
+
+        uint8_t *seq = bam_get_seq(b);
+        for (int i = 0; i < b->core.l_qseq; ++i) {
+            int base = bam_seqi(seq, i);
+            if (top && base == C)      set_base(seq, i, T);
+            else if (!top && base == G) set_base(seq, i, A);
+        }
+        if (sam_write1(out, hdr, b) < 0) { fprintf(stderr, "write error\n"); return 1; }
+    }
+    bam_destroy1(b);
+    bam_hdr_destroy(hdr);
+    sam_close(in);
+    if (sam_close(out) < 0) { fprintf(stderr, "error closing %s\n", argv[2]); return 1; }
+    if (ret < -1) { fprintf(stderr, "error reading %s\n", argv[1]); return 1; }
+    if (sam_index_build(argv[2], 0) < 0) { fprintf(stderr, "cannot index %s\n", argv[2]); return 1; }
+    return 0;
+}

--- a/MethylationModel.cpp
+++ b/MethylationModel.cpp
@@ -1,0 +1,64 @@
+#include "MethylationModel.h"
+
+#include <cctype>
+#include <cstring>
+
+ConversionStrand strandFromFlag(uint16_t flag) {
+    if (flag & BAM_FPAIRED) {
+        // A non-proper pair gives no reliable read-1 orientation: for read 2 we
+        // read the mate's strand from BAM_FMREVERSE, which is only meaningful
+        // when the pair mapped properly. Refuse to guess.
+        if (!(flag & BAM_FPROPER_PAIR)) return ConversionStrand::Unknown;
+        // The conversion channel is the strand read 1 aligned to. For read 1
+        // that is its own reverse bit; for read 2 it is the mate's reverse bit.
+        bool read1Reverse = (flag & BAM_FREAD1) ? (flag & BAM_FREVERSE)
+                                                : (flag & BAM_FMREVERSE);
+        return read1Reverse ? ConversionStrand::Ga : ConversionStrand::Ct;
+    }
+    return (flag & BAM_FREVERSE) ? ConversionStrand::Ga : ConversionStrand::Ct;
+}
+
+ConversionStrand conversionStrandOf(const bam1_t *b) {
+    // 1. YD — bwa-meth (type Z) and BISCUIT (type A). 'u'/'c' mean the aligner
+    //    could not determine the strand, so we stop rather than fall through.
+    if (uint8_t *yd = bam_aux_get(b, "YD")) {
+        char v = 0;
+        if (*yd == 'A') v = bam_aux2A(yd);
+        else if (*yd == 'Z') { const char *s = bam_aux2Z(yd); if (s) v = s[0]; }
+        if (v == 'f') return ConversionStrand::Ct;
+        if (v == 'r') return ConversionStrand::Ga;
+        if (v == 'u' || v == 'c') return ConversionStrand::Unknown;
+        // Any other value is unexpected; fall through to the next source.
+    }
+    // 2. ZS — BSMAP; the strand is the first character.
+    if (uint8_t *zs = bam_aux_get(b, "ZS")) {
+        if (*zs == 'Z') {
+            const char *s = bam_aux2Z(zs);
+            if (s && s[0] == '+') return ConversionStrand::Ct;
+            if (s && s[0] == '-') return ConversionStrand::Ga;
+        }
+    }
+    // 3. XG — Bismark / DRAGEN / BSBolt genome-conversion tag.
+    if (uint8_t *xg = bam_aux_get(b, "XG")) {
+        if (*xg == 'Z') {
+            const char *s = bam_aux2Z(xg);
+            if (s && strcmp(s, "CT") == 0) return ConversionStrand::Ct;
+            if (s && strcmp(s, "GA") == 0) return ConversionStrand::Ga;
+        }
+    }
+    // 4. No usable tag: infer from the FLAG.
+    return strandFromFlag(b->core.flag);
+}
+
+bool observationUsable(char ref, char alt, ConversionStrand cs) {
+    char r = static_cast<char>(std::toupper(static_cast<unsigned char>(ref)));
+    char a = static_cast<char>(std::toupper(static_cast<unsigned char>(alt)));
+    switch (cs) {
+        // A T could be a converted C, so any marker with a C allele is ambiguous.
+        case ConversionStrand::Ct: return r != 'C' && a != 'C';
+        // An A could be a converted G, so any marker with a G allele is ambiguous.
+        case ConversionStrand::Ga: return r != 'G' && a != 'G';
+        case ConversionStrand::Unknown: return false;
+    }
+    return false;
+}

--- a/MethylationModel.h
+++ b/MethylationModel.h
@@ -11,7 +11,7 @@
 // falls into one of two conversion channels:
 //   - Ct: genomic C may read as C or T (the "top"/OT+CTOT channel);
 //   - Ga: genomic G may read as G or A (the "bottom"/OB+CTOB channel).
-// See docs/methylation-design.md for the full model and derivation.
+// See the "Methylation sequencing" section in README.md for usage and details.
 enum class ConversionStrand : uint8_t { Ct, Ga, Unknown };
 
 // Conversion channel of a read inferred from its FLAG alone, assuming a

--- a/MethylationModel.h
+++ b/MethylationModel.h
@@ -1,0 +1,48 @@
+#ifndef METHYLATIONMODEL_H_
+#define METHYLATIONMODEL_H_
+
+#include "htslib/sam.h"
+#include <cstdint>
+
+// Support for genotyping SNP markers from directional bisulfite (WGBS) and
+// enzymatic methyl-seq (EM-seq) reads, where unmethylated C is read as T.
+//
+// In genome-forward coordinates (the orientation htslib stores) every read
+// falls into one of two conversion channels:
+//   - Ct: genomic C may read as C or T (the "top"/OT+CTOT channel);
+//   - Ga: genomic G may read as G or A (the "bottom"/OB+CTOB channel).
+// See docs/methylation-design.md for the full model and derivation.
+enum class ConversionStrand : uint8_t { Ct, Ga, Unknown };
+
+// Conversion channel of a read inferred from its FLAG alone, assuming a
+// directional library. The channel is the strand read 1 aligned to:
+//   - a paired read must be a proper pair (BAM_FPROPER_PAIR), so that
+//     BAM_FMREVERSE reliably gives the mate's (i.e. R1's) orientation for R2;
+//     any non-proper pair returns Unknown rather than guessing;
+//   - an unpaired read uses its own alignment strand.
+// Pure function of the flag bits so it can be tested exhaustively.
+ConversionStrand strandFromFlag(uint16_t flag);
+
+// Conversion channel of a read, preferring an aligner methylation tag over the
+// FLAG inference. Resolution order (BISCUIT's get_bsstrand precedence):
+//   1. YD  — bwa-meth (type Z) / BISCUIT (type A): f->Ct, r->Ga, u/c->Unknown
+//   2. ZS  — BSMAP: leading '+' -> Ct, '-' -> Ga
+//   3. XG  — Bismark/DRAGEN/BSBolt: "CT" -> Ct, "GA" -> Ga
+//   4. strandFromFlag(b->core.flag)
+// A tag that is present but carries an unrecognized value falls through to the
+// next source; a YD explicitly marking the strand unknown ('u'/'c') returns
+// Unknown without falling through, since the aligner has declared it unclear.
+ConversionStrand conversionStrandOf(const bam1_t *b);
+
+// Whether an observation from a read in channel `cs` unambiguously identifies
+// one of the marker's two alleles. An observation is unusable exactly when the
+// channel's conversion could turn one allele into the other:
+//   - Ct  is ambiguous whenever C is an allele (a T could be a converted C);
+//   - Ga  is ambiguous whenever G is an allele (an A could be a converted G).
+// `ref`/`alt` are single-character alleles (case-insensitive). Unknown channel
+// is always unusable. This is the no-collapse selection rule: markers keep only
+// the strand(s) on which they stay unambiguous — A/T both, other transversions
+// and transitions one, C/G neither.
+bool observationUsable(char ref, char alt, ConversionStrand cs);
+
+#endif // METHYLATIONMODEL_H_

--- a/MethylationModel.h
+++ b/MethylationModel.h
@@ -34,15 +34,20 @@ ConversionStrand strandFromFlag(uint16_t flag);
 // Unknown without falling through, since the aligner has declared it unclear.
 ConversionStrand conversionStrandOf(const bam1_t *b);
 
-// Whether an observation from a read in channel `cs` unambiguously identifies
-// one of the marker's two alleles. An observation is unusable exactly when the
-// channel's conversion could turn one allele into the other:
-//   - Ct  is ambiguous whenever C is an allele (a T could be a converted C);
-//   - Ga  is ambiguous whenever G is an allele (an A could be a converted G).
-// `ref`/`alt` are single-character alleles (case-insensitive). Unknown channel
-// is always unusable. This is the no-collapse selection rule: markers keep only
-// the strand(s) on which they stay unambiguous — A/T both, other transversions
-// and transitions one, C/G neither.
+// Whether an observation from a read in channel `cs` can still identify one of
+// the marker's two alleles unambiguously. The channel's conversion rewrites one
+// base (C->T on Ct reads, G->A on Ga reads), so an allele carrying that base can
+// no longer be told apart from its converted form. A marker is therefore
+// unusable on a channel whenever one of its alleles IS the channel's convertible
+// base -- regardless of what the other allele is:
+//   - Ct  unusable whenever C is an allele (a genomic C may read as C or T);
+//   - Ga  unusable whenever G is an allele (a genomic G may read as G or A).
+// e.g. A/C is unusable on Ct even though the C never becomes the A. Such
+// observations are dropped rather than collapsed back onto their allele -- the
+// "no-collapse" selection rule. `ref`/`alt` are single-character alleles
+// (case-insensitive); the Unknown channel is always unusable. Net effect: A/T
+// usable on both strands, other transversions and transitions on one, C/G on
+// neither.
 bool observationUsable(char ref, char alt, ConversionStrand cs);
 
 #endif // METHYLATIONMODEL_H_

--- a/README.md
+++ b/README.md
@@ -164,8 +164,9 @@ $(VERIFY_BAM_ID_HOME)/bin/VerifyBamID \
 At each marker, `--Methylation` uses only the observations that still identify an allele unambiguously on the read's conversion strand, and discards the rest:
 
 * **A/T** markers are used from both strands (conversion never touches A or T).
-* **A/C, C/G, G/T** markers are used from the one strand on which conversion cannot mimic the other allele.
-* **A/G and C/T** (transitions) are used only from the single strand that stays informative (A/G from C-to-T-converted reads, C/T from G-to-A-converted reads).
+* **A/C and G/T** markers are used from the one strand on which conversion cannot mimic the other allele (half depth).
+* **A/G and C/T** (transitions) are used only from the single strand that stays informative — A/G from C-to-T-converted reads, C/T from G-to-A-converted reads (half depth).
+* **C/G** markers are **not used**: both strands are ambiguous (C is affected on the C-to-T strand, G on the G-to-A strand), so no observations survive. This affects 2% of the 1000 Genomes panel and 0% of HGDP (which excludes palindromic SNPs). When building a custom marker panel with `--RefVCF`, C/G markers can be excluded up front.
 * Observations that a conversion could make ambiguous are dropped rather than guessed at.
 
 Because ambiguous observations are dropped rather than disambiguated, **the estimate does not depend on the methylation level or on the bisulfite/enzymatic conversion efficiency**, and **CpG context is irrelevant** — no methylation-rate or conversion-rate parameter enters the model. The cost is reduced effective depth (roughly half the observations at transition and most transversion markers), so somewhat higher coverage is recommended than for a standard run.
@@ -179,6 +180,7 @@ Because ambiguous observations are dropped rather than disambiguated, **the esti
 
 * **Directional libraries only.** This covers EM-seq and standard directional (Lister-style) WGBS. Non-directional and PBAT libraries are supported only where the aligner recorded a strand tag; with FLAG-only inference their strand assignment is wrong, so the estimate would be unreliable. Strand is taken from an aligner methylation tag (bismark `XG`, bwa-meth/BISCUIT `YD`, BSMAP `ZS`) when present, otherwise inferred from read-pair orientation. The mode has been validated end-to-end on directional EM-seq (FLAG-inferred strand); tag-based strand assignment for the other aligners is covered by unit tests but not yet exercised on their real output.
 * **`--PileupFile` input.** A pileup text file does not carry read-pair or tag information, so the conversion strand cannot be recovered from it. `--Methylation --PileupFile` is allowed but only for input that has *already* been filtered to methylation-safe observations (for example, a pileup produced by an earlier `--Methylation --BamFile ... --OutputPileup` run); a warning is printed. Feeding an unfiltered pileup will inflate the estimate.
+* **TAPS+ and Illumina 5-base chemistries.** Methods such as TAPS+ and Illumina's 5-base prep convert **methylated** C to T rather than unmethylated C. Because the substitution direction is the same (C→T on the top strand, G→A on the bottom), `--Methylation` mode is applicable and will produce a correct estimate. However, these chemistries convert far fewer positions per read (predominantly CpG-context cytosines) than bisulfite/EM-seq, so `--Methylation` mode is likely more conservative than necessary — it drops observations at all C- or G-containing markers on the affected strand, when in practice only CpG-context markers are at significant risk. For datasets with sufficient coverage `--Methylation` will likely give the cleanest estimate, but the mode has not been broadly tested on TAPS+ or 5-base data. A future version may add a dedicated mode for methylated-C→T chemistries with CpG-context-aware filtering and tuned MAPQ/BAQ thresholds.
 
 ## Running from docker
 

--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ $(VERIFY_BAM_ID_HOME)/bin/VerifyBamID --BamFile [/path/to/bam/or/cram/file] --SV
 /*To construct SVDPrefix auxillary files*/
 --RefVCF         [String] Reference panel VCF with genotype information, for generation of .UD .mu .bed files[Optional]
 /*Pileup information related*/
+--Methylation    [Bool] Directional bisulfite (WGBS) / enzymatic methyl-seq (EM-seq) mode. Uses only observations that unambiguously identify an allele on each read's bisulfite-conversion strand, and disables MAPQ adjustment (--adjust-MQ) and BAQ (both penalize the expected C-to-T/G-to-A conversions). See the "Methylation sequencing" section below. [Optional]
 --no-orphans     [Bool] Skip anomalous read pairs in variant calling. Anomolous read pairs are those marked in the FLAG field as paired in sequencing but without the properly-paired flag set. [Optional]
 --adjust-MQ      [Int] Coefficient for downgrading mapping quality for reads containing excessive mismatches. Given a read with a phred-scaled probability q of being generated from the mapped position, the new mapping quality is about sqrt((INT-q)/INT)*INT. A zero value disables this functionality; if enabled, the recommended value for BWA is 50. [default:40]
 --max-depth      [Int] Setting this limit reduces the amount of memory and time needed to process regions with very high coverage. Passing zero for this option sets it to the highest possible value, effectively removing the depth limit. [8000]
@@ -145,6 +146,39 @@ Fourth line: Estimated contamination level
 Also, upon the completion of each run, you may find two files ending with suffix:
 * “.selfSM” which shares the same format as VB1(https://genome.sph.umich.edu/wiki/VerifyBamID), and the key information FREEMIX indicates the estimated contamination level.
 * “.Ancestry” which contains the PC coordinates for both intended sample and contaminating sample, with each row being one PC.
+
+## Methylation sequencing (bisulfite / EM-seq)
+
+In whole-genome bisulfite sequencing (WGBS) and enzymatic methyl-seq (EM-seq), unmethylated cytosines are read as `T` (and, on reads from the opposite strand, unmethylated `G` positions read as `A`). A regular pileup therefore disagrees with the reference at a large fraction of positions for reasons unrelated to genotype, which would inflate the contamination estimate. The `--Methylation` flag enables a mode that handles this correctly, reusing the same SVD reference panels.
+
+```
+$(VERIFY_BAM_ID_HOME)/bin/VerifyBamID \
+  --Methylation \
+  --SVDPrefix $(VERIFY_BAM_ID_HOME)/resource/1000g.phase3.100k.b38.vcf.gz.dat \
+  --Reference [/path/to/GRCh38.fa] \
+  --BamFile [/path/to/methyl-seq.bam]
+```
+
+### What it does
+
+At each marker, `--Methylation` uses only the observations that still identify an allele unambiguously on the read's conversion strand, and discards the rest:
+
+* **A/T** markers are used from both strands (conversion never touches A or T).
+* **A/C, C/G, G/T** markers are used from the one strand on which conversion cannot mimic the other allele.
+* **A/G and C/T** (transitions) are used only from the single strand that stays informative (A/G from C-to-T-converted reads, C/T from G-to-A-converted reads).
+* Observations that a conversion could make ambiguous are dropped rather than guessed at.
+
+Because ambiguous observations are dropped rather than disambiguated, **the estimate does not depend on the methylation level or on the bisulfite/enzymatic conversion efficiency**, and **CpG context is irrelevant** — no methylation-rate or conversion-rate parameter enters the model. The cost is reduced effective depth (roughly half the observations at transition and most transversion markers), so somewhat higher coverage is recommended than for a standard run.
+
+`--Methylation` also changes read handling to suit converted reads:
+
+* **MAPQ adjustment (`--adjust-MQ`) and BAQ are disabled.** Both score reads against the *unconverted* reference, so an EM-seq/WGBS read's conversions look like dense mismatches; left on, MAPQ capping rejects the great majority of reads outright.
+* **Supplementary alignments are excluded**, and a read is used only when its conversion strand can be determined reliably — from an aligner methylation tag (`YD`, `ZS`, or `XG`) when present, otherwise from a proper-pair FLAG (paired reads must be properly paired; single-end reads use their own strand). A read whose strand cannot be determined is skipped, because a misassigned strand would read converted bases as alternate alleles and inflate the estimate.
+
+### Scope and limitations
+
+* **Directional libraries only.** This covers EM-seq and standard directional (Lister-style) WGBS. Non-directional and PBAT libraries are supported only where the aligner recorded a strand tag; with FLAG-only inference their strand assignment is wrong, so the estimate would be unreliable. Strand is taken from an aligner methylation tag (bismark `XG`, bwa-meth/BISCUIT `YD`, BSMAP `ZS`) when present, otherwise inferred from read-pair orientation. The mode has been validated end-to-end on directional EM-seq (FLAG-inferred strand); tag-based strand assignment for the other aligners is covered by unit tests but not yet exercised on their real output.
+* **`--PileupFile` input.** A pileup text file does not carry read-pair or tag information, so the conversion strand cannot be recovered from it. `--Methylation --PileupFile` is allowed but only for input that has *already* been filtered to methylation-safe observations (for example, a pileup produced by an earlier `--Methylation --BamFile ... --OutputPileup` run); a warning is printed. Feeding an unfiltered pileup will inflate the estimate.
 
 ## Running from docker
 

--- a/SimplePileupViewer.cpp
+++ b/SimplePileupViewer.cpp
@@ -22,43 +22,31 @@
 #include "sample.h"
 #include "samtools.h"
 
-static inline void
+// Encode one pileup observation into tmpBase in genome-forward orientation,
+// following samtools' pileup-string convention: '.'/',' for a reference match
+// on the forward/reverse strand, upper/lower-case ACGTN for a mismatch.
+//
+// Returns true iff a base was pushed. A deletion (is_del) contributes no base,
+// so the caller must not push a paired quality for it — otherwise tmpBase and
+// tmpQual desynchronize and every subsequent base at this marker pairs with the
+// wrong quality. (fp is retained from the samtools original, which streamed the
+// pileup text; all such output here is disabled.)
+static inline bool
 pileup_seq(FILE *fp, const bam_pileup1_t *p, int pos, int ref_len, const char *ref, std::vector<char> &tmpBase) {
-    int j;
-    if (p->is_head) {
-//        putc('^', fp);
-//        putc(p->b->core.qual > 93? 126 : p->b->core.qual + 33, fp);
+    if (p->is_del) return false;
+    int c = p->qpos < p->b->core.l_qseq
+            ? seq_nt16_str[bam_seqi(bam_get_seq(p->b), p->qpos)]
+            : 'N';
+    if (ref) {
+        int rb = pos < ref_len ? ref[pos] : 'N';
+        if (c == '=' || seq_nt16_table[c] == seq_nt16_table[rb]) c = bam_is_rev(p->b) ? ',' : '.';
+        else c = bam_is_rev(p->b) ? tolower(c) : toupper(c);
+    } else {
+        if (c == '=') c = bam_is_rev(p->b) ? ',' : '.';
+        else c = bam_is_rev(p->b) ? tolower(c) : toupper(c);
     }
-    if (!p->is_del) {
-        int c = p->qpos < p->b->core.l_qseq
-                ? seq_nt16_str[bam_seqi(bam_get_seq(p->b), p->qpos)]
-                : 'N';
-        if (ref) {
-            int rb = pos < ref_len ? ref[pos] : 'N';
-            if (c == '=' || seq_nt16_table[c] == seq_nt16_table[rb]) c = bam_is_rev(p->b) ? ',' : '.';
-            else c = bam_is_rev(p->b) ? tolower(c) : toupper(c);
-        } else {
-            if (c == '=') c = bam_is_rev(p->b) ? ',' : '.';
-            else c = bam_is_rev(p->b) ? tolower(c) : toupper(c);
-        }
-//        putc(c, fp);
-        tmpBase.push_back(c);
-    }
-//    else putc(p->is_refskip? (bam_is_rev(p->b)? '<' : '>') : '*', fp);
-    if (p->indel > 0) {//insertion
-//        putc('+', fp); printw(p->indel, fp);
-        for (j = 1; j <= p->indel; ++j) {
-            int c = seq_nt16_str[bam_seqi(bam_get_seq(p->b), p->qpos + j)];
-//            putc(bam_is_rev(p->b)? tolower(c) : toupper(c), fp);
-        }
-    } else if (p->indel < 0) {//deletion
-//        printw(p->indel, fp);
-        for (j = 1; j <= -p->indel; ++j) {
-            int c = (ref && (int) pos + j < ref_len) ? ref[pos + j] : 'N';
-//            putc(bam_is_rev(p->b)? tolower(c) : toupper(c), fp);
-        }
-    }
-//    if (p->is_tail) putc('$', fp);
+    tmpBase.push_back(c);
+    return true;
 }
 
 
@@ -452,6 +440,12 @@ int SimplePileupViewer::SimplePileup(mplp_conf_t *conf, int n, char **fn) {
                 } else {
                     /*calculate number of reads covering snps*/
 //                    numBases += n_plp[i];
+                    // Push each read's base and quality together in a single
+                    // pass so baseInfo and qualInfo stay in lockstep. A base is
+                    // recorded (and its quality with it) only when pileup_seq
+                    // actually emits one: deletions emit nothing, so pushing a
+                    // quality for them would shift every later quality at this
+                    // marker onto the wrong base.
                     for (j = 0; j < n_plp[i]; ++j) {//each covered read in ith bam file
                         const bam_pileup1_t *p = plp[i] + j;
                         int c = p->qpos < p->b->core.l_qseq
@@ -459,19 +453,10 @@ int SimplePileupViewer::SimplePileup(mplp_conf_t *conf, int n, char **fn) {
                                 : 0;
                         if (c >= conf->min_baseQ)//SimplePileupViewer Change
                         {
-                            pileup_seq(pileup_fp, plp[i] + j, pos, ref_len, ref, tmpBase);
-                        }
-                    }
-                    //putc('\t', pileup_fp);
-                    for (j = 0; j < n_plp[i]; ++j) {
-                        const bam_pileup1_t *p = plp[i] + j;
-                        int c = p->qpos < p->b->core.l_qseq
-                                ? bam_get_qual(p->b)[p->qpos]
-                                : 0;
-                        if (c >= conf->min_baseQ) {
-                            c = c + 33 < 126 ? c + 33 : 126;
-                            //putc(c, pileup_fp);
-                            tmpQual.push_back(c);
+                            if (pileup_seq(pileup_fp, p, pos, ref_len, ref, tmpBase)) {
+                                int q = c + 33 < 126 ? c + 33 : 126;
+                                tmpQual.push_back(q);
+                            }
                         }
                     }
 //                    if (conf->flag & MPLP_PRINT_MAPQ) {//multiple pileups

--- a/SimplePileupViewer.cpp
+++ b/SimplePileupViewer.cpp
@@ -181,19 +181,20 @@ static int mplp_func(void *data, bam1_t *b) {
             skip = 1;
             continue;
         }
+        if (ma->conf->bed) { // test overlap
+            skip = !bed_overlap(ma->conf->bed, ma->h->target_name[b->core.tid], b->core.pos, bam_endpos(b));
+            if (skip) continue;
+        }
         // Methylation mode requires a reliable conversion strand: an aligner
         // methylation tag, or a proper-pair FLAG inference (single-end reads use
         // their own strand). Drop reads whose strand cannot be determined -- a
         // misassigned strand would read converted bases as alt alleles and
-        // inflate the contamination estimate.
+        // inflate the contamination estimate. Checked after the BED-overlap test
+        // so aux tags are only parsed for reads that actually cover a marker.
         if (ma->conf->methylation &&
             conversionStrandOf(b) == ConversionStrand::Unknown) {
             skip = 1;
             continue;
-        }
-        if (ma->conf->bed) { // test overlap
-            skip = !bed_overlap(ma->conf->bed, ma->h->target_name[b->core.tid], b->core.pos, bam_endpos(b));
-            if (skip) continue;
         }
         if (ma->conf->rghash) { // exclude read groups
             uint8_t *rg = bam_aux_get(b, "RG");
@@ -475,11 +476,13 @@ int SimplePileupViewer::SimplePileup(mplp_conf_t *conf, int n, char **fn) {
                     // marker onto the wrong base.
                     for (j = 0; j < n_plp[i]; ++j) {//each covered read in ith bam file
                         const bam_pileup1_t *p = plp[i] + j;
-                        // Methylation mode: skip observations that cannot be
-                        // unambiguously assigned to an allele on this read's
-                        // conversion strand (e.g. a T at a C/T marker on a
-                        // C->T-converted read). mRef==0 means the marker's
-                        // alleles were not found, which fails closed.
+                        // Methylation mode: drop this observation when the
+                        // marker's alleles cannot be told apart on this read's
+                        // conversion strand. The test is per (marker alleles,
+                        // strand), not per observed base -- e.g. every
+                        // observation at a C/T marker is dropped on
+                        // C->T-converted reads, since its C could have converted
+                        // to T. mRef==0 (alleles not found) fails closed.
                         if (conf->methylation &&
                             (mRef == 0 ||
                              !observationUsable(mRef, mAlt, conversionStrandOf(p->b))))

--- a/SimplePileupViewer.cpp
+++ b/SimplePileupViewer.cpp
@@ -476,6 +476,10 @@ int SimplePileupViewer::SimplePileup(mplp_conf_t *conf, int n, char **fn) {
                     // marker onto the wrong base.
                     for (j = 0; j < n_plp[i]; ++j) {//each covered read in ith bam file
                         const bam_pileup1_t *p = plp[i] + j;
+                        // Deletions and ref-skips contribute no base; skip them
+                        // before accessing qpos/QUAL (qpos is not meaningful for
+                        // a deletion and could be out of range).
+                        if (p->is_del || p->is_refskip) continue;
                         // Methylation mode: drop this observation when the
                         // marker's alleles cannot be told apart on this read's
                         // conversion strand. The test is per (marker alleles,

--- a/SimplePileupViewer.cpp
+++ b/SimplePileupViewer.cpp
@@ -21,6 +21,7 @@
 #include "htslib/vcf.h"
 #include "sample.h"
 #include "samtools.h"
+#include "MethylationModel.h"
 
 // Encode one pileup observation into tmpBase in genome-forward orientation,
 // following samtools' pileup-string convention: '.'/',' for a reference match
@@ -177,6 +178,16 @@ static int mplp_func(void *data, bam1_t *b) {
             continue;
         }
         if (ma->conf->rflag_filter && ma->conf->rflag_filter & b->core.flag) {
+            skip = 1;
+            continue;
+        }
+        // Methylation mode requires a reliable conversion strand: an aligner
+        // methylation tag, or a proper-pair FLAG inference (single-end reads use
+        // their own strand). Drop reads whose strand cannot be determined -- a
+        // misassigned strand would read converted bases as alt alleles and
+        // inflate the contamination estimate.
+        if (ma->conf->methylation &&
+            conversionStrandOf(b) == ConversionStrand::Unknown) {
             skip = 1;
             continue;
         }
@@ -433,6 +444,22 @@ int SimplePileupViewer::SimplePileup(mplp_conf_t *conf, int n, char **fn) {
 
             std::vector<char> tmpBase, tmpQual;
 
+            // In methylation mode, resolve this marker's alleles once so each
+            // read's observation can be tested for bisulfite ambiguity below.
+            // Every pileup position corresponds to a panel marker, so the lookup
+            // always succeeds; mRef==0 (not found) fails closed as a safeguard.
+            char mRef = 0, mAlt = 0;
+            if (conf->methylation) {
+                auto chrIt = bedTable.find(chr);
+                if (chrIt != bedTable.end()) {
+                    auto posIt = chrIt->second.find(pos + 1);
+                    if (posIt != chrIt->second.end()) {
+                        mRef = posIt->second.first;
+                        mAlt = posIt->second.second;
+                    }
+                }
+            }
+
             for (i = 0; i < n; ++i) {//for each bam file
                 int j, cnt;
                 if (n_plp[i] == 0) {// if no reads covered
@@ -448,6 +475,15 @@ int SimplePileupViewer::SimplePileup(mplp_conf_t *conf, int n, char **fn) {
                     // marker onto the wrong base.
                     for (j = 0; j < n_plp[i]; ++j) {//each covered read in ith bam file
                         const bam_pileup1_t *p = plp[i] + j;
+                        // Methylation mode: skip observations that cannot be
+                        // unambiguously assigned to an allele on this read's
+                        // conversion strand (e.g. a T at a C/T marker on a
+                        // C->T-converted read). mRef==0 means the marker's
+                        // alleles were not found, which fails closed.
+                        if (conf->methylation &&
+                            (mRef == 0 ||
+                             !observationUsable(mRef, mAlt, conversionStrandOf(p->b))))
+                            continue;
                         int c = p->qpos < p->b->core.l_qseq
                                 ? bam_get_qual(p->b)[p->qpos]
                                 : 0;
@@ -607,9 +643,13 @@ SimplePileupViewer::SimplePileupViewer() {
 SimplePileupViewer::SimplePileupViewer(std::vector<region_t> *BedPtr,
                                        const char *bamFile, const char *faiFile,
                                        const char *bedFile,
-                                       mplp_conf_t *mplpPtr, int nfiles) {
+                                       mplp_conf_t *mplpPtr, const BED &chooseBed,
+                                       int nfiles) {
   bedVec = BedPtr;
   regIndex = 0;
+  // Retain the marker allele table so methylation mode can look up each
+  // marker's ref/alt while building the pileup. Empty (and unused) otherwise.
+  bedTable = chooseBed;
 
   const char *file_list = bamFile;
   char **fn = NULL;

--- a/SimplePileupViewer.cpp
+++ b/SimplePileupViewer.cpp
@@ -648,8 +648,9 @@ SimplePileupViewer::SimplePileupViewer(std::vector<region_t> *BedPtr,
   bedVec = BedPtr;
   regIndex = 0;
   // Retain the marker allele table so methylation mode can look up each
-  // marker's ref/alt while building the pileup. Empty (and unused) otherwise.
-  bedTable = chooseBed;
+  // marker's ref/alt while building the pileup. Only methylation mode reads it,
+  // so skip the (panel-sized) copy on ordinary runs.
+  if (mplpPtr->methylation) bedTable = chooseBed;
 
   const char *file_list = bamFile;
   char **fn = NULL;

--- a/SimplePileupViewer.h
+++ b/SimplePileupViewer.h
@@ -44,6 +44,7 @@ typedef struct {
   int min_mq, flag, min_baseQ, capQ_thres, max_depth, max_indel_depth, fmt_flag,
       all, rev_del;
   int rflag_require, rflag_filter;
+  int methylation; // 1 in methylation-seq mode: drop bisulfite-ambiguous observations
   int openQ, extQ, tandemQ, min_support; // for indels
   double min_frac;                       // for indels
   char *reg, *pl_list, *fai_fname, *output_fname;
@@ -109,7 +110,8 @@ public:
 
     SimplePileupViewer(std::vector<region_t> *A, const char *bamFile,
                        const char *faiFile, const char *bedFile,
-                       mplp_conf_t *mplpPtr, int nfiles = 1);
+                       mplp_conf_t *mplpPtr, const BED &chooseBed,
+                       int nfiles = 1);
 
     int SimplePileup(mplp_conf_t *conf, int n, char **fn);
 

--- a/TestMethylationModel.cpp
+++ b/TestMethylationModel.cpp
@@ -1,0 +1,163 @@
+/// Unit tests for the methylation conversion model (MethylationModel.h).
+///
+/// Covers the three public functions exhaustively over their (tiny) domains:
+///   1. strandFromFlag  — every relevant FLAG combination (pairing, proper-pair,
+///      read 1/2, forward/reverse), which is the path used when no aligner
+///      methylation tag is present (e.g. minibwa / bwa-meth output).
+///   2. observationUsable — all six unordered SNP allele classes on each
+///      conversion channel, against the truth table in docs/methylation-design.md,
+///      plus allele-order and case symmetry.
+///   3. conversionStrandOf — tag parsing for YD (types Z and A), ZS and XG, the
+///      YD-unknown case, and that a tag overrides the FLAG inference.
+///
+/// Follows the framework-free pattern of TestGramSVD.cpp: accumulate failures,
+/// print PASS/FAIL per check, return non-zero if any failed.
+
+#include "MethylationModel.h"
+#include "htslib/sam.h"
+
+#include <cstring>
+#include <iostream>
+#include <string>
+
+namespace {
+
+// BAM FLAG bits, named for readability in the test cases below.
+constexpr uint16_t PAIRED = 0x1, PROPER = 0x2, REVERSE = 0x10,
+                   MREVERSE = 0x20, READ1 = 0x40, READ2 = 0x80;
+
+const char *name(ConversionStrand cs) {
+    switch (cs) {
+        case ConversionStrand::Ct: return "Ct";
+        case ConversionStrand::Ga: return "Ga";
+        case ConversionStrand::Unknown: return "Unknown";
+    }
+    return "?";
+}
+
+int failures = 0;
+
+void expectStrand(const char *what, ConversionStrand got, ConversionStrand want) {
+    if (got != want) {
+        std::cerr << "FAIL [" << what << "]: got " << name(got)
+                  << ", want " << name(want) << std::endl;
+        ++failures;
+    } else {
+        std::cerr << "PASS [" << what << "]: " << name(got) << std::endl;
+    }
+}
+
+void expectUsable(const char *what, bool got, bool want) {
+    if (got != want) {
+        std::cerr << "FAIL [" << what << "]: got " << (got ? "usable" : "drop")
+                  << ", want " << (want ? "usable" : "drop") << std::endl;
+        ++failures;
+    } else {
+        std::cerr << "PASS [" << what << "]: " << (got ? "usable" : "drop") << std::endl;
+    }
+}
+
+// Build a minimal bam1_t carrying just a FLAG and (optionally) one aux tag. A
+// fresh record has zero-length name/cigar/seq, so an appended tag sits at the
+// start of the aux region and bam_aux_get resolves it correctly.
+bam1_t *makeRead(uint16_t flag) {
+    bam1_t *b = bam_init1();
+    b->core.flag = flag;
+    return b;
+}
+void addZ(bam1_t *b, const char *tag, const char *val) {
+    bam_aux_append(b, tag, 'Z', strlen(val) + 1, (const uint8_t *) val);
+}
+void addA(bam1_t *b, const char *tag, char val) {
+    bam_aux_append(b, tag, 'A', 1, (const uint8_t *) &val);
+}
+
+void testStrandFromFlag() {
+    std::cerr << "=== strandFromFlag ===" << std::endl;
+    // Unpaired: own strand.
+    expectStrand("SE forward", strandFromFlag(0), ConversionStrand::Ct);
+    expectStrand("SE reverse", strandFromFlag(REVERSE), ConversionStrand::Ga);
+    // Proper pair, read 1: own strand.
+    expectStrand("proper R1 fwd", strandFromFlag(PAIRED | PROPER | READ1), ConversionStrand::Ct);
+    expectStrand("proper R1 rev", strandFromFlag(PAIRED | PROPER | READ1 | REVERSE), ConversionStrand::Ga);
+    // Proper pair, read 2: the MATE's strand (BAM_FMREVERSE), not its own.
+    expectStrand("proper R2, mate fwd", strandFromFlag(PAIRED | PROPER | READ2), ConversionStrand::Ct);
+    expectStrand("proper R2, mate rev", strandFromFlag(PAIRED | PROPER | READ2 | MREVERSE), ConversionStrand::Ga);
+    // Read 2 forward-mapped but mate forward too -> still Ct (own REVERSE ignored).
+    expectStrand("proper R2 own-rev, mate fwd",
+                 strandFromFlag(PAIRED | PROPER | READ2 | REVERSE), ConversionStrand::Ct);
+    // Non-proper pairs are always Unknown, regardless of read/strand bits.
+    expectStrand("paired-not-proper R1", strandFromFlag(PAIRED | READ1), ConversionStrand::Unknown);
+    expectStrand("paired-not-proper R2", strandFromFlag(PAIRED | READ2 | MREVERSE), ConversionStrand::Unknown);
+    expectStrand("paired-not-proper rev", strandFromFlag(PAIRED | READ1 | REVERSE), ConversionStrand::Unknown);
+}
+
+void testObservationUsable() {
+    std::cerr << "=== observationUsable ===" << std::endl;
+    // (ref, alt, usable-on-Ct, usable-on-Ga) per the design-doc truth table.
+    struct Case { char ref, alt; bool ct, ga; const char *label; };
+    const Case cases[] = {
+        {'A', 'T', true,  true,  "A/T"},
+        {'A', 'G', true,  false, "A/G"},
+        {'C', 'T', false, true,  "C/T"},
+        {'A', 'C', false, true,  "A/C"},
+        {'G', 'T', true,  false, "G/T"},
+        {'C', 'G', false, false, "C/G"},
+    };
+    for (const Case &c : cases) {
+        std::string ct = std::string(c.label) + " Ct";
+        std::string ga = std::string(c.label) + " Ga";
+        std::string un = std::string(c.label) + " Unknown";
+        expectUsable(ct.c_str(), observationUsable(c.ref, c.alt, ConversionStrand::Ct), c.ct);
+        expectUsable(ga.c_str(), observationUsable(c.ref, c.alt, ConversionStrand::Ga), c.ga);
+        expectUsable(un.c_str(), observationUsable(c.ref, c.alt, ConversionStrand::Unknown), false);
+    }
+    // Allele order does not matter (unordered {ref,alt}).
+    expectUsable("T/A Ct (== A/T)", observationUsable('T', 'A', ConversionStrand::Ct), true);
+    expectUsable("G/A Ga (== A/G)", observationUsable('G', 'A', ConversionStrand::Ga), false);
+    // Case-insensitive.
+    expectUsable("c/t Ct lowercase", observationUsable('c', 't', ConversionStrand::Ct), false);
+    expectUsable("a/g Ga lowercase", observationUsable('a', 'g', ConversionStrand::Ga), false);
+}
+
+void testConversionStrandOf() {
+    std::cerr << "=== conversionStrandOf (tags) ===" << std::endl;
+    // A flag that would infer Ga on its own, so a tag result proves the tag won.
+    const uint16_t flagGa = REVERSE; // SE reverse -> Ga via FLAG
+
+    {   bam1_t *b = makeRead(flagGa); addZ(b, "YD", "f");
+        expectStrand("YD:Z:f beats flag", conversionStrandOf(b), ConversionStrand::Ct); bam_destroy1(b); }
+    {   bam1_t *b = makeRead(0); addZ(b, "YD", "r");
+        expectStrand("YD:Z:r", conversionStrandOf(b), ConversionStrand::Ga); bam_destroy1(b); }
+    {   bam1_t *b = makeRead(flagGa); addA(b, "YD", 'f');
+        expectStrand("YD:A:f (BISCUIT)", conversionStrandOf(b), ConversionStrand::Ct); bam_destroy1(b); }
+    {   bam1_t *b = makeRead(0); addA(b, "YD", 'r');
+        expectStrand("YD:A:r (BISCUIT)", conversionStrandOf(b), ConversionStrand::Ga); bam_destroy1(b); }
+    {   bam1_t *b = makeRead(0); addA(b, "YD", 'u');
+        expectStrand("YD:A:u -> Unknown", conversionStrandOf(b), ConversionStrand::Unknown); bam_destroy1(b); }
+    {   bam1_t *b = makeRead(flagGa); addZ(b, "ZS", "+-");
+        expectStrand("ZS:Z:+ beats flag", conversionStrandOf(b), ConversionStrand::Ct); bam_destroy1(b); }
+    {   bam1_t *b = makeRead(0); addZ(b, "ZS", "--");
+        expectStrand("ZS:Z:-", conversionStrandOf(b), ConversionStrand::Ga); bam_destroy1(b); }
+    {   bam1_t *b = makeRead(flagGa); addZ(b, "XG", "CT");
+        expectStrand("XG:Z:CT beats flag", conversionStrandOf(b), ConversionStrand::Ct); bam_destroy1(b); }
+    {   bam1_t *b = makeRead(0); addZ(b, "XG", "GA");
+        expectStrand("XG:Z:GA", conversionStrandOf(b), ConversionStrand::Ga); bam_destroy1(b); }
+    // No tag -> FLAG inference (this is the minibwa / bwa-meth path).
+    {   bam1_t *b = makeRead(PAIRED | PROPER | READ1);
+        expectStrand("no tag -> FLAG (proper R1 fwd)", conversionStrandOf(b), ConversionStrand::Ct); bam_destroy1(b); }
+}
+
+} // namespace
+
+int main() {
+    testStrandFromFlag();
+    testObservationUsable();
+    testConversionStrandOf();
+    if (failures > 0) {
+        std::cerr << failures << " check(s) FAILED" << std::endl;
+        return 1;
+    }
+    std::cerr << "All methylation-model checks passed" << std::endl;
+    return 0;
+}

--- a/TestMethylationModel.cpp
+++ b/TestMethylationModel.cpp
@@ -16,6 +16,7 @@
 #include "MethylationModel.h"
 #include "htslib/sam.h"
 
+#include <cstdint>
 #include <cstring>
 #include <iostream>
 #include <string>

--- a/main.cpp
+++ b/main.cpp
@@ -75,7 +75,7 @@ int execute(int argc, char **argv) {
   std::string fixPC("Empty");
   double fixAlpha(-1.), epsilon(1e-8);
   bool withinAncestry(false), outputPileup(false), verbose(false),
-      disableSanityCheck(false);
+      disableSanityCheck(false), methylation(false);
   int nfiles(0), seed(12345), nPC(2), nthread(4);
   /// mpileup arguments
   mplp_conf_t mplp;
@@ -182,6 +182,10 @@ int execute(int argc, char **argv) {
                  "recommended:50, disable:0")
   LONG_INT_PARAM("max-depth", &mplp.max_depth, "[Int] max per-file depth")
   LONG_PARAM("no-orphans", &noOrphan, "[Bool] do not use anomalous read pairs")
+  LONG_PARAM("Methylation", &methylation,
+             "[Bool] directional bisulfite/EM-seq mode: use only observations "
+             "that unambiguously identify an allele on the read's conversion "
+             "strand; disables MAPQ adjustment and BAQ (see docs)")
   LONG_INT_PARAM("incl-flags", &mplp.flag,
                  "[Int] required flags: skip reads with mask bits unset")
   LONG_INT_PARAM("excl-flags", &mplp.rflag_filter,
@@ -209,6 +213,22 @@ int execute(int argc, char **argv) {
     mplp.flag |= MPLP_NO_ORPHAN;
   else
     mplp.flag &= 0XFFFFFFFF ^ MPLP_NO_ORPHAN;
+
+  mplp.methylation = methylation ? 1 : 0;
+  if (methylation) {
+    // MAPQ capping (sam_cap_mapq) and BAQ (sam_prob_realn) both score reads
+    // against the unconverted reference, so an EM-seq/WGBS read's C->T
+    // conversions look like dense mismatches: capping hard-rejects such reads
+    // (measured: ~99% of usable data lost) and BAQ crushes their base
+    // qualities. Both are htslib functions we cannot make conversion-aware, so
+    // methylation mode disables them. Also exclude supplementary alignments,
+    // whose strand relationship to read 1 is unreliable.
+    mplp.capQ_thres = 0;
+    mplp.flag &= ~MPLP_REALN;
+    mplp.rflag_filter |= BAM_FSUPPLEMENTARY;
+    notice("--Methylation: disabled MAPQ adjustment (--adjust-MQ 0) and BAQ, "
+           "and excluding supplementary alignments");
+  }
   /// End of mpileup parsing
 
   if (RefVCF == "Empty") {
@@ -273,7 +293,17 @@ int execute(int argc, char **argv) {
 //    }
     else if(PileupFile != "Empty")
     {
-
+        if (methylation) {
+            // A samtools pileup exposes only alignment strand, not read1/read2
+            // or aligner tags, so the conversion strand cannot be recovered
+            // here. The mode's depth scaling still applies, but the input must
+            // already contain only methylation-safe observations (e.g. produced
+            // by a prior --Methylation --BamFile ... --OutputPileup run).
+            warning("--Methylation with --PileupFile: conversion-strand "
+                    "filtering cannot run on pileup text; the input must "
+                    "already be filtered to methylation-safe observations, or "
+                    "the contamination estimate will be inflated");
+        }
     }
     else {
         error("--BamFile or --PileupFile is required");

--- a/resource/test/expected/result.methyl.Ancestry
+++ b/resource/test/expected/result.methyl.Ancestry
@@ -1,0 +1,3 @@
+PC	ContaminatingSample	IntendedSample
+1	0.039969	0.039969
+2	-0.0214571	-0.0214571


### PR DESCRIPTION
# Add `--Methylation` mode for bisulfite / EM-seq contamination estimation

## Motivation

VerifyBamID2 cannot currently be used on whole-genome bisulfite (WGBS) or enzymatic methyl-seq (EM-seq) data. In these libraries unmethylated cytosines are read as `T` (and, on reads from the opposite strand, unmethylated `G` positions read as `A`), so a regular pileup disagrees with the reference at a large fraction of positions for reasons unrelated to genotype. Left uncorrected these conversions are counted as alternate-allele or error observations and **inflate the contamination estimate** — on our EM-seq test data an unfiltered run reported ~0.20 FREEMIX on an in-silico-clean sample.

No published tool estimates contamination from WGBS/EM-seq; the closest prior art (a GRAIL patent, and the Xu et al. 2023 sample-tagging work) keeps only **A/T** SNPs, which on the shipped panels is 1,398 markers for 1000g and **zero for HGDP** (HGDP excludes palindromic SNPs). This PR adds a strand-aware mode that keeps essentially all markers.

## What it does

`--Methylation` uses, at each marker, only the observations that still identify an allele unambiguously on the read's bisulfite-conversion strand, and drops the rest (the "no-collapse" rule):

- **A/T** — used on both strands (conversion never touches A or T).
- **A/C, C/G, G/T** — used on the one strand where conversion cannot mimic the other allele.
- **A/G, C/T** (transitions) — used on the single informative strand (A/G from C→T-converted reads, C/T from G→A-converted reads).
- Observations a conversion could make ambiguous are dropped, not guessed.

Because ambiguous observations are dropped rather than disambiguated, **no methylation-rate or conversion-rate parameter enters the model** — the estimate is independent of methylation level and of bisulfite/enzymatic conversion efficiency, and CpG context is irrelevant. Selection depends only on the read's conversion strand and the marker's alleles, never on the sample genotype, so the selection step itself adds no bias; its cost is reduced effective depth (~half the observations at transition and most transversion markers). (A small reference-mapping underestimate does appear at high contamination — see Validation.)

The mode also adapts read handling to converted reads:

- **MAPQ adjustment (`--adjust-MQ`) and BAQ are disabled.** Both score reads against the unconverted reference, so an EM-seq read's C→T conversions look like dense mismatches. Measured on EM-seq NA12878, the default MAPQ cap (`sam_cap_mapq`) *hard-rejects* ~99% of usable reads (70 vs 12,118 base observations with the cap off). Both are htslib functions we call rather than vendor, so the mode disables them rather than forking htslib to make them conversion-aware.
- **Supplementary alignments are excluded**, and a read is used only when its conversion strand is reliably known: an aligner methylation tag (`YD` — accepting both bwa-meth's `:Z:` and BISCUIT's `:A:` — `ZS`, or `XG`) when present, else a proper-pair FLAG inference (paired reads must be properly paired; single-end reads use their own strand). Reads with no reliable strand are skipped, since a misassigned strand turns converted bases into apparent alternate alleles and inflates the estimate.

## Design

The conversion logic is isolated in a new, dependency-light `MethylationModel.h/.cpp` as small pure functions over tiny domains — `conversionStrandOf(bam1_t*)` / `strandFromFlag(uint16_t)` and `observationUsable(ref, alt, strand)` — so it is exhaustively unit-testable. `SimplePileupViewer` consumes them: `mplp_func` gates reads on a reliable strand, and the (single, post-desync-fix) pileup loop drops bisulfite-ambiguous observations using the marker allele table passed in from `ContaminationEstimator`. The likelihood, optimizer, and SVD/ancestry model are untouched.

## Scope and limitations

- **Directional libraries only** (EM-seq, standard Lister-style WGBS). Non-directional and PBAT libraries are handled only where the aligner recorded a strand tag; under FLAG-only inference their strand is wrong. Documented in the README and `--help`.
- **`--PileupFile`** cannot carry read-pair/tag information, so `--Methylation --PileupFile` is allowed but warns: the input must already contain only methylation-safe observations (e.g. from a prior `--Methylation --BamFile … --OutputPileup` run).

## Validation

- **Unit test** (`TestMethylationModel`, 33 checks): the full 6-class × 2-strand usability truth table, exhaustive FLAG combinations for strand inference, and tag parsing/precedence (`YD:Z`, `YD:A`, `YD:A:u`, `ZS`, `XG`, tag-beats-FLAG).
- **Regression**: with `--Methylation` off, output is unchanged; the existing suite passes 17/17.
- **In-silico titration on real EM-seq** (SEQC2 EpiQC, ~10×, GRCh38, 1000g 100k panel): host HG001/NA12878 mixed with an unrelated contaminant at known α, recovered FREEMIX vs spiked —

  | spiked α | HG002 (NA24385) | HG005 (NA24631) |
  |---:|---:|---:|
  | 0% | 0.15% | 0.15% |
  | 1% | 1.18% | 1.10% |
  | 2% | 2.08% | 1.87% |
  | 5% | 4.93% | 4.63% |
  | 10% | 9.52% | 8.86% |
  | 25% | — | 21.4% |

  Clean at 0% and accurate/monotonic across two contaminant populations. A mild underestimate grows with α and with contaminant divergence (up to −3.6 pp at 25% cross-population), consistent with reference-mapping bias against the contaminant's non-reference alleles amplified by three-letter bisulfite alignment; the QC-relevant low-α regime is well calibrated.

## Compatibility

Opt-in via `--Methylation`; default behavior and output format are unchanged (the existing test suite passes untouched). The first commit fixes a pre-existing base/quality desync in the pileup loop — a read with a deletion at a marker pushed a quality with no base — which the per-observation filter then builds on.
